### PR TITLE
Capitalize patchmanager entry on the jolla-settings menu

### DIFF
--- a/src/plugin/patchmanager.json
+++ b/src/plugin/patchmanager.json
@@ -4,7 +4,7 @@
         {
             "path": "system_settings/look_and_feel/patchmanager",
             "type": "page",
-            "title": "patchmanager",
+            "title": "Patchmanager",
             "translation_id": "settings-patchmanager-patchmanager",
             "icon": "/usr/share/patchmanager/icons/icon-m-patchmanager.png",
             "order": 2000,


### PR DESCRIPTION
The commit only changes "patchmanager" to "Patchmanager" in order to have the entry capitalized in the jolla-settings app. (All entries are with capital letter, i found it ugly to have patchmanager entry starting with lowercase").