### PR TITLE
Sort web patches by category and name

### DIFF
--- a/src/qml/WebCatalogPage.qml
+++ b/src/qml/WebCatalogPage.qml
@@ -41,6 +41,7 @@ Page {
     property var versions
     property string search
     property bool searchVisible
+    property bool sortByDate: true
 
     onStatusChanged: {
         if (status == PageStatus.Active) {
@@ -84,13 +85,21 @@ Page {
                     searchVisible = !searchVisible
                 }
             }
+            MenuItem {
+                text: sortByDate ? qsTranslate("", "Sort by Category") : qsTranslate("", "Sort by Date")
+                onClicked: {
+                    sortByDate = !sortByDate
+                }
+            }
+
         }
 
         header: Component {
             Column {
                 width: view.width
                 PageHeader {
-                    title: container.author ? qsTranslate("", "%1 patches").arg(container.author) : qsTranslate("", "Web catalog")
+                    title: container.author ? qsTranslate("", "%1 patches").arg(container.author) : qsTranslate("", "Web catalog") 
+                    description: container.sortByDate ? qsTranslate("", "(by date updated)") : qsTranslate("", "(by category)")
                 }
 
                 SearchField {
@@ -130,15 +139,22 @@ Page {
         }
         model: WebPatchesModel {
             id: patchModel
-            queryParams:  container.author ? { 'author': container.author }
-                                           : container.search ? { 'display_name__contains': container.search }
-                                                              : {}
+            sorted: !container.sortByDate
+            queryParams: {
+                var p = {};
+                if (container.author)  p = { 'author': container.author };
+                if (container.search)  p = { 'display_name__contains': container.search };
+                return p;
+            }
         }
         section.criteria: ViewSection.FullString
         section.delegate: SectionHeader {
-            text: qsTranslate("Sections", section)
+            text: container.sortByDate ? "" : qsTranslate("Sections", section)
+            font.capitalization: Font.Capitalize
+            height: text.length > 0 ? implicitHeight : 0
+            visible: text.length > 0
         }
-        section.property: "category"
+        section.property: container.sortByDate ? "undefined" : "category"
         currentIndex: -1
         spacing: Theme.paddingSmall
 
@@ -167,7 +183,7 @@ Page {
                     width: parent.width
                     Label {
                         id: nameLabel
-                        width: parent.width - authorLabel.width - Theme.paddingMedium
+                        width: parent.width - secondaryLabel.width - Theme.paddingMedium
                         text: model.display_name
                         color: background.down ? Theme.highlightColor : Theme.primaryColor
                         font.bold: isInstalled
@@ -175,11 +191,11 @@ Page {
                     }
 
                     Label {
-                        id: authorLabel
+                        id: secondaryLabel
                         anchors.right: parent.right
                         anchors.verticalCenter: parent.verticalCenter
                         font.pixelSize: Theme.fontSizeExtraSmall
-                        text: model.author
+                        text: container.sortByDate ? model.category : model.author
                         color: Theme.secondaryHighlightColor
                     }
                 }

--- a/src/qml/webpatchesmodel.cpp
+++ b/src/qml/webpatchesmodel.cpp
@@ -123,34 +123,29 @@ void WebPatchesModel::componentComplete()
                 const QLatin1String category("category");
                 const QLatin1String name("display_name");
                 const QByteArray other("other");
-                std::sort(catalog.begin(), catalog.end(),
-                    [&category, &name, &other](const QVariant &a, const QVariant &b)
-                    {
+                std::sort(catalog.begin(), catalog.end(), [&category, &name, &other](const QVariant &a, const QVariant &b) {
                     const auto amap = a.toMap();
                     const auto bmap = b.toMap();
 
                     const auto acat = amap[category].toByteArray();
                     const auto bcat = bmap[category].toByteArray();
 
-                    if (acat == bcat)
-                    {
-                    // If categories are equal then sort by name
-                    return compareStrings(amap[name].toString(), bmap[name].toString());
+                    if (acat == bcat) {
+                        // If categories are equal then sort by name
+                        return compareStrings(amap[name].toString(), bmap[name].toString());
                     }
 
                     // Move others to the end
-                    if (acat == other)
-                    {
-                    return false;
+                    if (acat == other) {
+                        return false;
                     }
-                    if (bcat == other)
-                    {
-                      return true;
+                    if (bcat == other) {
+                        return true;
                     }
 
                     // Sort by localized category name
                     return compareStrings(translateCategory(acat), translateCategory(bcat));
-                    });
+                });
             }
 
             beginInsertRows(QModelIndex(), 0, catalog.count() - 1);

--- a/src/qml/webpatchesmodel.cpp
+++ b/src/qml/webpatchesmodel.cpp
@@ -36,6 +36,8 @@
 #include <QDBusPendingReply>
 #include <QDebug>
 
+#include <algorithm>
+
 WebPatchesModel::WebPatchesModel(QObject * parent)
     : QAbstractListModel(parent)
 {
@@ -82,6 +84,16 @@ void WebPatchesModel::classBegin()
 
 }
 
+QString translateCategory(const QByteArray &category)
+{
+    return QCoreApplication::translate("Sections", category.data());
+}
+
+bool compareStrings(const QString &a, const QString &b)
+{
+    return a.compare(b, Qt::CaseInsensitive) < 0;
+}
+
 void WebPatchesModel::componentComplete()
 {
     if (_modelData.size() > 0) {
@@ -94,8 +106,40 @@ void WebPatchesModel::componentComplete()
     connect(watcher, &QDBusPendingCallWatcher::finished, [this](QDBusPendingCallWatcher *watcher){
         QDBusPendingReply<QVariantList> reply = *watcher;
         if (!reply.isError()) {
-            const QVariantList catalog = PatchManager::unwind(reply.value()).toList();
+            QVariantList catalog = PatchManager::unwind(reply.value()).toList();
             qDebug() << Q_FUNC_INFO << catalog.count();
+
+            const QLatin1String category("category");
+            const QLatin1String name("display_name");
+            const QByteArray other("other");
+            std::sort(catalog.begin(), catalog.end(),
+                [&category, &name, &other](const QVariant &a, const QVariant &b)
+                {
+                    const auto amap = a.toMap();
+                    const auto bmap = b.toMap();
+
+                    const auto acat = amap[category].toByteArray();
+                    const auto bcat = bmap[category].toByteArray();
+
+                    if (acat == bcat)
+                    {
+                        // If categories are equal then sort by name
+                        return compareStrings(amap[name].toString(), bmap[name].toString());
+                    }
+
+                    // Move others to the end
+                    if (acat == other)
+                    {
+                        return false;
+                    }
+                    if (bcat == other)
+                    {
+                        return true;
+                    }
+
+                    // Sort by localized category name
+                    return compareStrings(translateCategory(acat), translateCategory(bcat));
+                });
 
             beginInsertRows(QModelIndex(), 0, catalog.count() - 1);
             _modelData = catalog;

--- a/src/qml/webpatchesmodel.h
+++ b/src/qml/webpatchesmodel.h
@@ -49,6 +49,9 @@ public:
     Q_PROPERTY(QVariantMap queryParams READ queryParams WRITE setQueryParams NOTIFY queryParamsChanged)
     QVariantMap queryParams() const;
     void setQueryParams(const QVariantMap & queryParams);
+    Q_PROPERTY(bool sorted READ sorted WRITE setSorted NOTIFY sortedChanged)
+    bool sorted() const { return _sorted; };
+    void setSorted(const bool & sorted);
 
     explicit WebPatchesModel(QObject * parent = 0);
     virtual ~WebPatchesModel();
@@ -63,6 +66,7 @@ public:
 private:
     QVariantMap _queryParams;
     bool _completed;
+    bool _sorted;
 
     QNetworkAccessManager * _nam;
 
@@ -72,6 +76,7 @@ private:
 
 signals:
     void queryParamsChanged(const QVariantMap & queryParams);
+    void sortedChanged();
 
 };
 


### PR DESCRIPTION
Sort patches by localized category and displayed name. The "other" category is always displayed at the end of the list.