### PR TITLE
Add aarch64 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,14 @@ jobs:
             mb2 -t SailfishOS-$RELEASE-armv7hl build ;
             sudo cp -r RPMS/*.rpm /share/output"
 
+    - name: Build aarch64
+      run: docker run --rm --privileged -v $PWD:/share coderus/sailfishos-platform-sdk:$RELEASE /bin/bash -c "
+            mkdir -p build ;
+            cd build ;
+            cp -r /share/* . ;
+            mb2 -t SailfishOS-$RELEASE-aarch64 build ;
+            sudo cp -r RPMS/*.rpm /share/output"
+
     - name: Build i486
       run: docker run --rm --privileged -v $PWD:/share coderus/sailfishos-platform-sdk:$RELEASE /bin/bash -c "
             mkdir -p build ;
@@ -37,7 +45,7 @@ jobs:
             cp -r /share/* . ;
             mb2 -t SailfishOS-$RELEASE-i486 build ;
             sudo cp -r RPMS/*.rpm /share/output"
-      
+
     - name: Upload build result
       uses: actions/upload-artifact@v2
       with:

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -125,6 +125,7 @@ case "$*" in
 0)
 echo "Uninstalling %{name}: postun section"
 sed -i "/libpreloadpatchmanager/ d" /etc/ld.so.preload
+/sbin/ldconfig
 rm -rf /tmp/patchmanager || true
 rm -f /tmp/patchmanager-socket || true
 ;;
@@ -133,7 +134,6 @@ echo "Updating %{name}: postun section"
 ;;
 *) echo "Case $* is not handled in postun section of %{name}!"
 esac
-/sbin/ldconfig
 dbus-send --system --type=method_call \
 --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
 systemctl daemon-reload

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -96,13 +96,8 @@ echo "Updating %{name}: post section"
 ;;
 *) echo "Case $* is not handled in post section of %{name}!"
 esac
-ARCH="$(getconf LONG_BIT)"
-SUFFIX="$([ "$ARCH" = "64" ] && echo "64" || echo "")"
-if grep -qF libpreloadpatchmanager /etc/ld.so.preload; then
-    echo "Preload entry already exists in /etc/ld.so.preload"
-else
-    echo "/usr/lib$SUFFIX/libpreloadpatchmanager.so" >> /etc/ld.so.preload
-fi
+sed -i "/libpreload%{name}/ d" /etc/ld.so.preload
+echo "%{_libdir}/libpreload%{name}.so" >> /etc/ld.so.preload
 /sbin/ldconfig
 dbus-send --system --type=method_call \
 --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -69,7 +69,7 @@ echo "Installing %{name}: pre section"
 ;;
 2)
 echo "Updating %{name}: pre section"
-# Unapply patches if Patchmanager 2.x is installed
+# Unapply all patches if Patchmanager 2.x is installed
 if [ ! -d /var/lib/patchmanager/ausmt/patches/ ]
 then
     exit 0

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -95,10 +95,12 @@ echo Upgrading package
 ;;
 *) echo case "$*" not handled in post
 esac
+ARCH=$(getconf LONG_BIT)
+SUFFIX=$([[ "$ARCH" == "64" ]] && echo "64" || echo "")
 if grep libpreloadpatchmanager /etc/ld.so.preload > /dev/null; then
     echo "Preload already exists"
 else
-    echo /usr/lib/libpreloadpatchmanager.so >> /etc/ld.so.preload
+    echo /usr/lib$SUFFIX/libpreloadpatchmanager.so >> /etc/ld.so.preload
 fi
 /sbin/ldconfig
 dbus-send --system --type=method_call \
@@ -158,7 +160,7 @@ systemctl-user daemon-reload
 %{_userunitdir}/dbus-org.SfietKonstantin.patchmanager.service
 %{_userunitdir}/lipstick-patchmanager.service
 %{_userunitdir}/lipstick.service.wants/lipstick-patchmanager.service
-/usr/lib/libpreload%{name}.so
+%{_libdir}/libpreload%{name}.so
 
 %attr(0755,root,root-) %{_libexecdir}/pm_apply
 %attr(0755,root,root-) %{_libexecdir}/pm_unapply

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -124,7 +124,7 @@ export NO_PM_PRELOAD=1
 case "$*" in
 0)
 echo "Uninstalling %{name}: postun section"
-sed -i "/libpreloadpatchmanager/ d" /etc/ld.so.preload
+sed -i "/libpreload%{name}/ d" /etc/ld.so.preload
 /sbin/ldconfig
 rm -rf /tmp/patchmanager || true
 rm -f /tmp/patchmanager-socket || true

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -74,7 +74,7 @@ if [ ! -d /var/lib/patchmanager/ausmt/patches/ ]
 then
     exit 0
 else
-    /usr/sbin/patchnamager --unapply-all || true
+    /usr/sbin/patchmanager --unapply-all || true
 fi
 if [ -n "$(ls -A /var/lib/patchmanager/ausmt/patches/)" ]
 then

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -56,8 +56,8 @@ ln -s ../dbus-org.SfietKonstantin.patchmanager.service %{buildroot}%{_unitdir}/m
 mkdir -p %{buildroot}%{_unitdir}/timers.target.wants/
 ln -s ../checkForUpdates-org.SfietKonstantin.patchmanager.timer %{buildroot}%{_unitdir}/timers.target.wants/
 
-mkdir -p %{buildroot}/usr/lib/systemd/user/lipstick.service.wants/
-ln -s ../lipstick-patchmanager.service %{buildroot}/usr/lib/systemd/user/lipstick.service.wants/
+mkdir -p %{buildroot}/%{_userunitdir}/lipstick.service.wants/
+ln -s ../lipstick-patchmanager.service %{buildroot}/%{_userunitdir}/lipstick.service.wants/
 
 mkdir -p %{buildroot}%{_datadir}/%{name}/patches
 

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -158,7 +158,7 @@ systemctl-user daemon-reload
 %{_userunitdir}/dbus-org.SfietKonstantin.patchmanager.service
 %{_userunitdir}/lipstick-patchmanager.service
 %{_userunitdir}/lipstick.service.wants/lipstick-patchmanager.service
-%{_libdir}/libpreload%{name}.so
+/usr/lib/libpreload%{name}.so
 
 %attr(0755,root,root-) %{_libexecdir}/pm_apply
 %attr(0755,root,root-) %{_libexecdir}/pm_unapply

--- a/src/preload/preload.pro
+++ b/src/preload/preload.pro
@@ -12,6 +12,6 @@ SOURCES += \
     src/preloadpatchmanager.c
 
 TARGET = preloadpatchmanager
-target.path = /usr/lib
+target.path = $$LIBDIR
 
 INSTALLS = target


### PR DESCRIPTION
This adds the correct lib64 location for the preloaded so.
Also, because a previous version of this might have been installed from b100dian OBS or chum, which used the 64-bit binary in /lib/, that needs to be cleared from ld.so.preload.


<details>
<summary>Old description</summary>
Without bash installed, the busybox shell was erroring out with "Substitution failure".
This changes the script to no longer need `${PIPESTATUS[0]}` which is the cause of the above failure.

Also, when building for aarch64, there is some mismatch between where a lib is packaged and where is looked up. The 'fix' is to currently just hardcode "lib" - that's why I say its' the naive fix, only to unblock building/running.
</details>