### PR TITLE
[ui] add Remorse Popup to Unapply All menu action

### DIFF
--- a/src/qml/PatchManagerPage.qml
+++ b/src/qml/PatchManagerPage.qml
@@ -145,7 +145,7 @@ Page {
 
             MenuItem {
                 text: qsTranslate("", "Unapply all patches")
-                onClicked: PatchManager.call(PatchManager.unapplyAllPatches())
+                onClicked: menuRemorse.execute( text, function() { PatchManager.call(PatchManager.unapplyAllPatches()) } )
                 visible: PatchManager.loaded
             }
 
@@ -509,7 +509,7 @@ Page {
             enabled: view.count == 0
             text: qsTranslate("", "No patches available")
         }
-
+        RemorsePopup { id: menuRemorse }
         VerticalScrollDecorator {}
     }
 


### PR DESCRIPTION
"Unapply All" menu option is destructive - add a remorse timer to it to avoid "fat-fingering"

See Issue #20
https://github.com/sailfishos-patches/patchmanager/issues/20