### PR TITLE
[firejail] add and install our own whitelist

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -99,6 +99,11 @@ esac
 sed -i "/libpreload%{name}/ d" /etc/ld.so.preload
 echo "%{_libdir}/libpreload%{name}.so" >> /etc/ld.so.preload
 /sbin/ldconfig
+if grep 'include whitelist-common-patchmanager.local' /etc/firejail/whitelist-common.local > /dev/null; then
+    echo "Firejail whitelist already exists"
+else
+    echo 'include whitelist-common-patchmanager.local' >> /etc/firejail/whitelist-common.local
+fi
 dbus-send --system --type=method_call \
 --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
 systemctl daemon-reload
@@ -124,6 +129,7 @@ export NO_PM_PRELOAD=1
 case "$*" in
 0)
 echo "Uninstalling %{name}: postun section"
+sed -i "/whitelist-common-patchmanager.local/ d" /etc/firejail/whitelist-common.local ||:
 sed -i "/libpreload%{name}/ d" /etc/ld.so.preload
 /sbin/ldconfig
 rm -rf /tmp/patchmanager || true

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -129,11 +129,11 @@ export NO_PM_PRELOAD=1
 case "$*" in
 0)
 echo "Uninstalling %{name}: postun section"
-sed -i "/whitelist-common-patchmanager.local/ d" /etc/firejail/whitelist-common.local || true
+sed -i "/whitelist-common-patchmanager.local/ d" /etc/firejail/whitelist-common.local
 sed -i "/libpreload%{name}/ d" /etc/ld.so.preload
 /sbin/ldconfig
-rm -rf /tmp/patchmanager || true
-rm -f /tmp/patchmanager-socket || true
+rm -rf /tmp/patchmanager
+rm -f /tmp/patchmanager-socket
 ;;
 1)
 echo "Updating %{name}: postun section"

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -129,7 +129,7 @@ export NO_PM_PRELOAD=1
 case "$*" in
 0)
 echo "Uninstalling %{name}: postun section"
-sed -i "/whitelist-common-patchmanager.local/ d" /etc/firejail/whitelist-common.local ||:
+sed -i "/whitelist-common-patchmanager.local/ d" /etc/firejail/whitelist-common.local || true
 sed -i "/libpreload%{name}/ d" /etc/ld.so.preload
 /sbin/ldconfig
 rm -rf /tmp/patchmanager || true

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -163,8 +163,8 @@ systemctl-user daemon-reload
 %{_libdir}/libpreload%{name}.so
 %{_sysconfdir}/firejail/whitelist-common-%{name}.local
 
-%attr(0755,root,root-) %{_libexecdir}/pm_apply
-%attr(0755,root,root-) %{_libexecdir}/pm_unapply
+%attr(0755,root,root) %{_libexecdir}/pm_apply
+%attr(0755,root,root) %{_libexecdir}/pm_unapply
 
 %{_libdir}/qt5/qml/org/SfietKonstantin/%{name}
 %{_datadir}/%{name}/data

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -61,6 +61,8 @@ ln -s ../lipstick-patchmanager.service %{buildroot}/%{_userunitdir}/lipstick.ser
 
 mkdir -p %{buildroot}%{_datadir}/%{name}/patches
 
+install -m 644 -D src/etc/whitelist-common-patchmanager.local %{buildroot}%{_sysconfdir}/firejail/whitelist-common-patchmanager.local
+
 %pre
 export NO_PM_PRELOAD=1
 case "$*" in
@@ -163,6 +165,7 @@ systemctl-user daemon-reload
 %{_userunitdir}/lipstick-patchmanager.service
 %{_userunitdir}/lipstick.service.wants/lipstick-patchmanager.service
 %{_libdir}/libpreload%{name}.so
+%{_sysconfdir}/firejail/whitelist-common-patchmanager.local
 
 %attr(0755,root,root-) %{_libexecdir}/pm_apply
 %attr(0755,root,root-) %{_libexecdir}/pm_unapply
@@ -180,3 +183,4 @@ systemctl-user daemon-reload
 %{_datadir}/themes/%{theme}/meegotouch/z1.5-large/icons/*.png
 %{_datadir}/themes/%{theme}/meegotouch/z1.75/icons/*.png
 %{_datadir}/themes/%{theme}/meegotouch/z2.0/icons/*.png
+

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -99,10 +99,8 @@ esac
 sed -i '/libpreload%{name}/ d' /etc/ld.so.preload
 echo '%{_libdir}/libpreload%{name}.so' >> /etc/ld.so.preload
 /sbin/ldconfig
-if grep -qF 'include whitelist-common-%{name}.local' /etc/firejail/whitelist-common.local; then
-    echo "Firejail whitelist entry for %{name} already exists."
-else
-    echo 'include whitelist-common-%{name}.local' >> /etc/firejail/whitelist-common.local
+if ! grep -qsF 'include whitelist-common-%{name}.local' /etc/firejail/whitelist-common.local; then
+   echo 'include whitelist-common-%{name}.local' >> /etc/firejail/whitelist-common.local
 fi
 dbus-send --system --type=method_call \
 --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -61,8 +61,6 @@ ln -s ../lipstick-patchmanager.service %{buildroot}/%{_userunitdir}/lipstick.ser
 
 mkdir -p %{buildroot}%{_datadir}/%{name}/patches
 
-install -m 644 -D src/etc/whitelist-common-patchmanager.local %{buildroot}%{_sysconfdir}/firejail/whitelist-common-patchmanager.local
-
 %pre
 export NO_PM_PRELOAD=1
 case "$*" in

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -96,13 +96,13 @@ echo "Updating %{name}: post section"
 ;;
 *) echo "Case $* is not handled in post section of %{name}!"
 esac
-sed -i "/libpreload%{name}/ d" /etc/ld.so.preload
-echo "%{_libdir}/libpreload%{name}.so" >> /etc/ld.so.preload
+sed -i '/libpreload%{name}/ d' /etc/ld.so.preload
+echo '%{_libdir}/libpreload%{name}.so' >> /etc/ld.so.preload
 /sbin/ldconfig
-if grep 'include whitelist-common-patchmanager.local' /etc/firejail/whitelist-common.local > /dev/null; then
-    echo "Firejail whitelist already exists"
+if grep -qF 'include whitelist-common-%{name}.local' /etc/firejail/whitelist-common.local; then
+    echo "Firejail whitelist entry for %{name} already exists."
 else
-    echo 'include whitelist-common-patchmanager.local' >> /etc/firejail/whitelist-common.local
+    echo 'include whitelist-common-%{name}.local' >> /etc/firejail/whitelist-common.local
 fi
 dbus-send --system --type=method_call \
 --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
@@ -129,8 +129,8 @@ export NO_PM_PRELOAD=1
 case "$*" in
 0)
 echo "Uninstalling %{name}: postun section"
-sed -i "/whitelist-common-patchmanager.local/ d" /etc/firejail/whitelist-common.local
-sed -i "/libpreload%{name}/ d" /etc/ld.so.preload
+sed -i '/whitelist-common-%{name}.local/ d' /etc/firejail/whitelist-common.local
+sed -i '/libpreload%{name}/ d' /etc/ld.so.preload
 /sbin/ldconfig
 rm -rf /tmp/patchmanager
 rm -f /tmp/patchmanager-socket
@@ -163,7 +163,7 @@ systemctl-user daemon-reload
 %{_userunitdir}/lipstick-patchmanager.service
 %{_userunitdir}/lipstick.service.wants/lipstick-patchmanager.service
 %{_libdir}/libpreload%{name}.so
-%{_sysconfdir}/firejail/whitelist-common-patchmanager.local
+%{_sysconfdir}/firejail/whitelist-common-%{name}.local
 
 %attr(0755,root,root-) %{_libexecdir}/pm_apply
 %attr(0755,root,root-) %{_libexecdir}/pm_unapply

--- a/src/etc/etc.pro
+++ b/src/etc/etc.pro
@@ -1,0 +1,6 @@
+TEMPLATE = aux
+
+firejail.files = whitelist-common-patchmanager.local
+firejail.path = /etc/firejail
+INSTALLS += firejail
+

--- a/src/etc/whitelist-common-patchmanager.local
+++ b/src/etc/whitelist-common-patchmanager.local
@@ -1,0 +1,5 @@
+### patchmanager for sailjailed apps
+whitelist /tmp/patchmanager-socket
+whitelist /tmp/patchmanager
+whitelist /tmp/patchmanager3
+private-etc ld.so.preload

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,2 +1,2 @@
 TEMPLATE = subdirs
-SUBDIRS = bin qml share plugin icons preload tools
+SUBDIRS = bin etc qml share plugin icons preload tools


### PR DESCRIPTION
See Issue #55 for discussion.

Installs a new file `whitelist-common-patchmanager.local`, and adds an include line to `/etc/firejail/whitelist-common.local`.

Tested on 4.0/Xperia10-DS and 4.2/GeminiPDA, works.