### PR TITLE
Increase version number & add dep to SFOS >= 3.4.0

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -8,7 +8,7 @@
 Name:       patchmanager
 
 Summary:    Patchmanager allows for managing Sailfish OS patches
-Version:    3.0.1
+Version:    3.1.0
 Release:    1
 Group:      Qt/Qt
 License:    TODO
@@ -16,6 +16,7 @@ URL:        https://github.com/sailfishos-patches/patchmanager
 Source0:    %{name}-%{version}.tar.bz2
 Requires:   unzip
 Requires:   patch
+Requires:   sailfish-version >= 3.4.0
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Qml)

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -48,7 +48,8 @@ rm -rf %{buildroot}
 
 %qmake5_install
 
-/usr/lib/qt5/bin/qmlplugindump -v -noinstantiate -nonrelocatable org.SfietKonstantin.patchmanager 2.0 %{buildroot}%{_libdir}/qt5/qml > %{buildroot}%{_libdir}/qt5/qml/org/SfietKonstantin/%{name}/plugin.qmltypes |:
+/usr/lib/qt5/bin/qmlplugindump -noinstantiate -nonrelocatable org.SfietKonstantin.patchmanager 2.0 %{buildroot}%{_libdir}/qt5/qml \
+> %{buildroot}%{_libdir}/qt5/qml/org/SfietKonstantin/%{name}/plugin.qmltypes 2> /dev/null || true
 sed -i 's#%{buildroot}##g' %{buildroot}%{_libdir}/qt5/qml/org/SfietKonstantin/%{name}/plugin.qmltypes
 
 mkdir -p %{buildroot}%{_unitdir}/multi-user.target.wants/
@@ -103,8 +104,7 @@ echo '%{_libdir}/libpreload%{name}.so' >> /etc/ld.so.preload
 if ! grep -qsF 'include whitelist-common-%{name}.local' /etc/firejail/whitelist-common.local; then
    echo 'include whitelist-common-%{name}.local' >> /etc/firejail/whitelist-common.local
 fi
-dbus-send --system --type=method_call \
---dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
+dbus-send --system --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
 systemctl daemon-reload
 systemctl-user daemon-reload
 systemctl restart dbus-org.SfietKonstantin.patchmanager.service
@@ -139,8 +139,7 @@ echo "Updating %{name}: postun section"
 ;;
 *) echo "Case $* is not handled in postun section of %{name}!"
 esac
-dbus-send --system --type=method_call \
---dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
+dbus-send --system --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
 systemctl daemon-reload
 systemctl-user daemon-reload
 


### PR DESCRIPTION
Increase version number & add dep to SFOS >= 3.4.0
- Increase version number from 3.0.1 to 3.1.0
- Add runtime dependency to SailfishOS >= 3.4.0, because I always hated that Patchmanager was installable on old SailfishOS releases, which it does not support any more.