### PR TITLE
Fix pageStack.push doesn't throw exception when file is missing. Fixes #54

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ patchmanager_adaptor.*
 patchmanager-dialog
 
 .build*
+src/icons/z*
+src/icons/ss
+*.list

--- a/src/qml/PatchManagerPage.qml
+++ b/src/qml/PatchManagerPage.qml
@@ -383,14 +383,14 @@ Page {
 
             onClicked: {
                 var patchName = patchObject.details.patch
-                try {
+                var qmlFile = "/usr/share/patchmanager/patches/%1/main.qml".arg(patchName)
+                if (PatchManager.fileExists(qmlFile)) {
                     var translator = PatchManager.installTranslator(patchName)
                     var page = pageStack.push("/usr/share/patchmanager/patches/%1/main.qml".arg(patchName))
                     if (translator) {
                         page.Component.destruction.connect(function() { PatchManager.removeTranslator(patchName) })
                     }
-                }
-                catch(err) {
+                } else {
                     openPatchInfo()
                 }
             }

--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -775,6 +775,11 @@ bool PatchManagerTranslator::installTranslator(const QString &patch)
     return true;
 }
 
+bool PatchManager::fileExists(const QString &filename)
+{
+    return QFile::exists(filename);
+}
+
 bool PatchManagerTranslator::removeTranslator(const QString &patch)
 {
     qDebug() << Q_FUNC_INFO << patch;

--- a/src/qml/patchmanager.h
+++ b/src/qml/patchmanager.h
@@ -131,6 +131,7 @@ public slots:
     void checkEaster();
     QString iconForPatch(const QString &patch, bool dark = true) const;
     QString valueIfExists(const QString & filename) const;
+    bool fileExists(const QString &filename);
 
     void checkForUpdates();
 


### PR DESCRIPTION

Navigating to a non-existing page does not throw anymore - test existence first.

Cherry-picking @elros34's https://github.com/elros34/patchmanager/commit/54cf701439bf41b2d4d9ebaff1389ff9f62fa84d in spirit + authorship