### PR TITLE
Show warning label for conflicting patches

### DIFF
--- a/src/qml/PatchManagerPage.qml
+++ b/src/qml/PatchManagerPage.qml
@@ -445,7 +445,7 @@ Page {
                     anchors.right: patchIcon.status == Image.Ready ? patchIcon.left : parent.right
                     anchors.margins: Theme.paddingMedium
                     anchors.verticalCenter: parent.verticalCenter
-                    text: name
+                    text: ( patchObject.details.conflicts.length > 0 ) ? name + " ⚠": name
                     color: patchObject.details.isCompatible ? background.down ? Theme.highlightColor : Theme.primaryColor
                                                             : background.down ? Qt.tint(Theme.highlightColor, "red") : Qt.tint(Theme.primaryColor, "red")
                     truncationMode: TruncationMode.Fade
@@ -481,7 +481,7 @@ Page {
                     }
                     MenuLabel {
                         visible: patchObject.details.conflicts.length > 0
-                        text: qsTranslate("", "Have possible conflicts")
+                        text: qsTranslate("", "May have conflicts")
                     }
                     MenuItem {
                         text: qsTranslate("", "Patch info")

--- a/src/qml/settings-patchmanager.ts
+++ b/src/qml/settings-patchmanager.ts
@@ -190,8 +190,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="PatchManagerPage.qml" line="484"/>
-        <source>Have possible conflicts</source>
+        <location filename="PatchManagerPage.qml" line="485"/>
+        <source>May have conflicts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Add a (Unicode) warning character to patch names if they might conflict with others.
Also fixes spelling of the corresponding warning.