### PR TITLE
Fix PR 64: Move from SsuRelease to OsRelease

### DIFF
--- a/src/bin/patchmanager-daemon/dbus/org.SfietKonstantin.patchmanager.xml
+++ b/src/bin/patchmanager-daemon/dbus/org.SfietKonstantin.patchmanager.xml
@@ -62,7 +62,7 @@
         <method name="checkEaster">
             <arg name="easter" type="s" direction="out" />
         </method>
-        <method name="getSsuVersion">
+        <method name="getOsVersion">
             <arg name="version" type="s" direction="out" />
         </method>
         <method name="getPatchmanagerVersion">

--- a/src/bin/patchmanager-daemon/patchmanagerobject.cpp
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.cpp
@@ -283,7 +283,9 @@ void PatchManagerObject::setAppliedPatches(const QSet<QString> &patches)
 void PatchManagerObject::getVersion()
 {
     qDebug() << Q_FUNC_INFO;
-    m_osRelease  = QSettings("/etc/os-release", QSettings::IniFormat).value("VERSION_ID").toString();
+    m_osRelease = QSettings("/etc/os-release", QSettings::IniFormat).value("VERSION_ID").toString();
+    qDebug() << "Received OS version:" << m_osRelease;
+    lateInitialize();
 }
 
 void PatchManagerObject::lateInitialize()

--- a/src/bin/patchmanager-daemon/patchmanagerobject.cpp
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.cpp
@@ -197,7 +197,7 @@ bool PatchManagerObject::makePatch(const QDir &root, const QString &patchPath, Q
         json[COMPATIBLE_KEY] = QStringList();
         json[ISCOMPATIBLE_KEY] = true;
     } else {
-        json[ISCOMPATIBLE_KEY] = json[COMPATIBLE_KEY].toStringList().contains(m_ssuRelease);
+        json[ISCOMPATIBLE_KEY] = json[COMPATIBLE_KEY].toStringList().contains(m_osRelease);
     }
     json[CONFLICTS_KEY] = QStringList();
     patch = json;
@@ -283,23 +283,7 @@ void PatchManagerObject::setAppliedPatches(const QSet<QString> &patches)
 void PatchManagerObject::getVersion()
 {
     qDebug() << Q_FUNC_INFO;
-    QDBusMessage msg = QDBusMessage::createMethodCall(QStringLiteral("org.nemo.ssu"),
-                                                      QStringLiteral("/org/nemo/ssu"),
-                                                      QStringLiteral("org.nemo.ssu"),
-                                                      QStringLiteral("release"));
-    msg.setArguments({ QVariant::fromValue(false) });
-    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(QDBusConnection::systemBus().asyncCall(msg), this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, [this](QDBusPendingCallWatcher *watcher) {
-        watcher->deleteLater();
-        if (!watcher->isError()) {
-            m_ssuRelease = QDBusPendingReply<QString>(*watcher);
-            qDebug() << "Received ssu version:" << m_ssuRelease;
-            lateInitialize();
-        } else {
-            qWarning() << "Ssu version request error!" << watcher->error();
-            QCoreApplication::exit(2);
-        }
-    });
+    m_osRelease  = QSettings("/etc/os-release", QSettings::IniFormat).value("VERSION_ID").toString();
 }
 
 void PatchManagerObject::lateInitialize()
@@ -1352,9 +1336,9 @@ QString PatchManagerObject::getPatchmanagerVersion() const
     return QCoreApplication::applicationVersion();
 }
 
-QString PatchManagerObject::getSsuVersion() const
+QString PatchManagerObject::getOsVersion() const
 {
-    return m_ssuRelease;
+    return m_osRelease;
 }
 
 //void PatchManagerObject::checkPatches()
@@ -2250,7 +2234,7 @@ void PatchManagerObject::requestCheckForUpdates()
 
     QUrl url(QStringLiteral(CATALOG_URL "/" PROJECTS_PATH));
     QUrlQuery query;
-    query.addQueryItem("version", m_ssuRelease);
+    query.addQueryItem("version", m_osRelease);
     url.setQuery(query);
     QNetworkRequest request(url);
     QNetworkReply *reply = m_nam->get(request);
@@ -2326,7 +2310,7 @@ void PatchManagerObject::requestCheckForUpdates()
                 for (const QVariant &fileVar : files) {
                     const QVariantMap file = fileVar.toMap();
                     const QStringList compatible = file.value("compatible").toStringList();
-                    if (!compatible.contains(m_ssuRelease)) {
+                    if (!compatible.contains(m_osRelease)) {
                         continue;
                     }
                     const QString version = file.value("version").toString();

--- a/src/bin/patchmanager-daemon/patchmanagerobject.h
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.h
@@ -132,7 +132,7 @@ public slots:
     void lipstickChanged(const QString &state);
 
     QString getPatchmanagerVersion() const;
-    QString getSsuVersion() const;
+    QString getOsVersion() const;
 
 protected:
     bool eventFilter(QObject *watched, QEvent *event);
@@ -235,7 +235,8 @@ private:
 
     QVariantMap m_updates;
 
-    QString m_ssuRelease;
+    QString m_osRelease;
+
     PatchManagerAdaptor *m_adaptor = nullptr;
     QNetworkAccessManager *m_nam = nullptr;
 


### PR DESCRIPTION
Should fix some fallout from PR #65, which removed Ssu calls from patchmanager, but left pachmanagerobject still using ssu values. 

This led to the compatibility checks on web catalog patch pages failing (all versions displayed as incompatible).
