### PR TITLE
Fix zip package handling, enhance decompression capabilities

### DIFF
--- a/src/bin/patchmanager-daemon/patchmanagerobject.cpp
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.cpp
@@ -82,7 +82,9 @@ if (!calledFromDBus()) {\
 }
 
 static const QString PATCHES_DIR = QStringLiteral("/usr/share/patchmanager/patches");
-static const QString PATCHES_ADDITIONAL_DIR = QStringLiteral("/tmp/patchmanager3/patches");
+static const QString PATCHES_WORK_DIR_PREFIX = QStringLiteral("/tmp/patchmanager3");
+static const QString PATCHES_WORK_DIR = QStringLiteral("%1/%2").arg(PATCHES_WORK_DIR_PREFIX, "work");
+static const QString PATCHES_ADDITIONAL_DIR = QStringLiteral("%1/%2").arg(PATCHES_WORK_DIR_PREFIX, "patches");
 static const QString PATCH_FILE = QStringLiteral("patch.json");
 
 static const QString NAME_KEY = QStringLiteral("name");
@@ -1883,10 +1885,15 @@ void PatchManagerObject::downloadPatchArchive(const QVariantMap &params, const Q
     const QString &url = params.value(QStringLiteral("url")).toString();
     const QString &patch = params.value(QStringLiteral("patch")).toString();
     const QString &json = params.value(QStringLiteral("json")).toString();
-    const QString &archive = QStringLiteral("/tmp/%1").arg(url.section(QChar('/'), -1));
+    const QString &archive = QStringLiteral("%1/%2").arg(PATCHES_WORK_DIR, url.section(QChar('/'), -1));
     const QString &version = params.value(QStringLiteral("version")).toString();
 
     qDebug() << Q_FUNC_INFO << "Saving archive to" << archive;
+    QDir workDir(PATCHES_WORK_DIR);
+    if (!workDir.mkpath(PATCHES_WORK_DIR)) {
+            qDebug() << Q_FUNC_INFO << QStringLiteral("Error: could not create ") << workDir;
+            return;
+    };
     QFile *archiveFile = new QFile(archive, this);
     if (!archiveFile->open(QFile::WriteOnly)) {
         return;


### PR DESCRIPTION
I noticed during dogfooding that downloading packages from Web Catalog which have .zip packages would not work.

The download would complete successfully, but then the patchmanager daemon would start unzipping, and the unzip child process would hang indefinitely (apparently waiting for input on fd 0).  
This then causes the patchmanager daemon to hang while it waits.

Suspecting this might have to do with zip packages being placed in `/tmp`, I moved that location within `/tmp/patchmanager3/work`, and changed the call to unzip to force-overwrite files in the target dir. This makes unzipping work again, although I'm not exactly sure why.

This PR also includes two other enhancements:

 - make all paths to external binaries static constants on the top of the source file
 - support more than just .tar.gz tarball packages (tar.bz2, tar.xz...) - although Web Catalog doesn't support those at the moment.

Please review (for clarity, lookat the commits individually) and let me know:

 - do you see the unzipping problem with current PM as well? Does this fix it for you if yes? The example package that showed the problem for me is https://coderus.openrepos.net/pm2/project/email-list-view-line-count
 - do you find the additional tarball support useful? I can rip it out again as it is not useful at the moment.