### PR TITLE
[ui] Add option to suppress notifications

### DIFF
--- a/src/bin/patchmanager-daemon/patchmanagerobject.cpp
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.cpp
@@ -225,10 +225,6 @@ void PatchManagerObject::notify(const QString &patch, NotifyAction action)
     QVariantList remoteActions;
 
     switch (action) {
-    case NotifyActionNone:
-        qDebug() << Q_FUNC_INFO << "Notification suppressed.";
-        return;
-        break; //well...
     case NotifyActionSuccessApply:
         summary = qApp->translate("", "Patch installed");
         body = qApp->translate("", "Patch %1 installed").arg(patch);
@@ -1879,12 +1875,13 @@ void PatchManagerObject::doPatch(const QVariantMap &params, const QDBusMessage &
         }
     }
 
-    // is this used anywhere??
+    // is this parameter used anywhere??
     if (!params.value(QStringLiteral("dont_notify"), false).toBool()) {
-        if (getSettings(QStringLiteral("notifyOnSuccess"), true).toBool()) {
-            notify(displayName.toString(), apply ? ok ? NotifyActionSuccessApply : NotifyActionFailedApply : ok ? NotifyActionSuccessUnapply : NotifyActionFailedUnapply);
+        bool donotify = getSettings(QStringLiteral("notifyOnSuccess"), true).toBool();
+        if (ok && donotify) {
+            notify(displayName.toString(), apply ? NotifyActionSuccessApply : NotifyActionSuccessUnapply);
         } else {
-            notify(displayName.toString(), apply ? ok ? NotifyActionNone : NotifyActionFailedApply : ok ? NotifyActionNone : NotifyActionFailedUnapply);
+            notify(displayName.toString(), apply ? NotifyActionFailedApply : NotifyActionFailedUnapply);
         }
     }
 

--- a/src/bin/patchmanager-daemon/patchmanagerobject.h
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.h
@@ -85,6 +85,7 @@ public:
         NotifyActionFailedApply,
         NotifyActionFailedUnapply,
         NotifyActionUpdateAvailable,
+        NotifyActionNone,
     };
     Q_ENUM(NotifyAction)
 

--- a/src/bin/patchmanager-daemon/patchmanagerobject.h
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.h
@@ -86,7 +86,6 @@ public:
         NotifyActionFailedApply,
         NotifyActionFailedUnapply,
         NotifyActionUpdateAvailable,
-        NotifyActionNone,
     };
     Q_ENUM(NotifyAction)
 

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -16,6 +16,18 @@ Page {
                 title: qsTranslate("", "Settings")
             }
 
+            SectionHeader { text: qsTranslate("", "General") }
+
+            TextSwitch {
+                text: qsTranslate("", "Show notification on success")
+                description: qsTranslate("", "If this is off, notifications will only be shown when something went wrong")
+                checked: PatchManager.notifyOnSuccess
+                onClicked: PatchManager.notifyOnSuccess = !PatchManager.notifyOnSuccess
+                automaticCheck: false
+            }
+
+            SectionHeader { text: qsTranslate("", "Advanced") }
+
             TextSwitch {
                 text: qsTranslate("", "Apply patches when booting")
                 description: qsTranslate("", "Automatically apply all enabled patches when Sailfish OS starts")

--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -204,6 +204,18 @@ void PatchManager::setApplyOnBoot(bool applyOnBoot)
     }
 }
 
+bool PatchManager::notifyOnSuccess() const
+{
+    return getSettingsSync(QStringLiteral("notifyOnSuccess"), true).toBool();
+}
+
+void PatchManager::setNotifyOnSuccess(bool notifyOnSuccess)
+{
+    if (putSettingsSync(QStringLiteral("notifyOnSuccess"), notifyOnSuccess)) {
+        emit notifyOnSuccessChanged(notifyOnSuccess);
+    }
+}
+
 PatchManagerModel *PatchManager::installedModel()
 {
     return m_installedModel;

--- a/src/qml/patchmanager.h
+++ b/src/qml/patchmanager.h
@@ -66,6 +66,7 @@ class PatchManager: public QObject
     Q_PROPERTY(QString serverMediaUrl READ serverMediaUrl CONSTANT)
     Q_PROPERTY(bool developerMode READ developerMode WRITE setDeveloperMode NOTIFY developerModeChanged)
     Q_PROPERTY(bool applyOnBoot READ applyOnBoot WRITE setApplyOnBoot NOTIFY applyOnBootChanged)
+    Q_PROPERTY(bool notifyOnSuccess READ notifyOnSuccess WRITE setNotifyOnSuccess NOTIFY notifyOnSuccessChanged)
     Q_PROPERTY(PatchManagerModel *installedModel READ installedModel CONSTANT)
     Q_PROPERTY(QVariantMap updates READ getUpdates NOTIFY updatesChanged)
     Q_PROPERTY(QStringList updatesNames READ getUpdatesNames NOTIFY updatesChanged)
@@ -82,7 +83,9 @@ public:
     bool developerMode() const;
     void setDeveloperMode(bool developerMode);
     bool applyOnBoot() const;
+    bool notifyOnSuccess() const;
     void setApplyOnBoot(bool applyOnBoot);
+    void setNotifyOnSuccess(bool notifyOnSuccess);
     PatchManagerModel *installedModel();
     QString trCategory(const QString &category) const;
     QVariantMap getUpdates() const;
@@ -156,6 +159,7 @@ signals:
     void easterReceived(const QString & easterText);
     void developerModeChanged(bool developerMode);
     void applyOnBootChanged(bool applyOnBoot);
+    void notifyOnSuccessChanged(bool notifyOnSuccess);
     void updatesChanged();
     void toggleServicesChanged(bool toggleServices);
     void failureChanged(bool failed);


### PR DESCRIPTION
When applying a lot of patches the notification popups get in the way, and clutter the Notification view.

This allows the user to turn off success notifications for applying patches.