### PR TITLE
l18n: Adapt to bitness nomenclature and fix all line number references

### DIFF
--- a/src/bin/dialog/dialog.qml
+++ b/src/bin/dialog/dialog.qml
@@ -60,8 +60,8 @@ ApplicationWindow {
         Page {
             onStatusChanged: {
                 if (status == PageStatus.Active && !appWindow.remorseItem) {
-                    remorse.execute(button, qsTranslate("", "Activate all Patches marked active"), function() {
-                        console.info("Accepted activation of all Patches marked active.")
+                    remorse.execute(button, qsTranslate("", "Activate all enabled Patches"), function() {
+                        console.info("Accepted activation of all enabled Patches.")
                         dbusPm.call("loadRequest", [true])
                     }, 10000)
                     appWindow.remorseItem = remorse
@@ -77,7 +77,7 @@ ApplicationWindow {
                     width: parent.width
 
                     PageHeader {
-                        title: qsTranslate("", "Activate all Patches marked active")
+                        title: qsTranslate("", "Activate all enabled Patches")
                     }
 
                     Label {
@@ -85,7 +85,7 @@ ApplicationWindow {
                         anchors.right: parent.right
                         anchors.margins: Theme.horizontalPageMargin
                         wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-                        text: qsTranslate("", "Patchmanager will activate all Patches marked active in 10 seconds.")
+                        text: qsTranslate("", "Patchmanager will start to activate all enabled Patches in 10 seconds.")
                     }
 
                     Item {
@@ -105,7 +105,7 @@ ApplicationWindow {
                             RemorseItem {
                                 id: remorse
                                 onCanceled: {
-                                    console.info("Cancelled activation of all Patches marked active.")
+                                    console.info("Cancelled activation of all enabled Patches.")
                                     dbusPm.call("loadRequest", [false])
                                     Qt.quit()
                                 }
@@ -168,8 +168,8 @@ ApplicationWindow {
                 function autoApplyingFinished(success) {
                     console.info(success)
                     button.enabled = true
-                    progress.label = success ? qsTranslate("", "Successfully activated all Patches marked active.")
-                                             : qsTranslate("", "Failed to activate all Patches marked active!")
+                    progress.label = success ? qsTranslate("", "Successfully activated all enabled Patches.")
+                                             : qsTranslate("", "Failed to activate all enabled Patches!")
                 }
             }
         }

--- a/src/bin/patchmanager-daemon/patchmanagerobject.cpp
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.cpp
@@ -232,7 +232,7 @@ void PatchManagerObject::notify(const QString &patch, NotifyAction action)
     switch (action) {
     case NotifyActionSuccessApply:
         summary = qApp->translate("", "Patch activated");
-        body = qApp->translate("", "Patch %1 activated").arg(patch);
+        body = qApp->translate("", "Patch %1 activated.").arg(patch);
         if (getToggleServices()) {
             body.append( ", " );
             body.append( qApp->translate("", "some service should be restarted.") );
@@ -243,10 +243,10 @@ void PatchManagerObject::notify(const QString &patch, NotifyAction action)
         break;
     case NotifyActionSuccessUnapply:
         summary = qApp->translate("", "Patch deactivated");
-        body = qApp->translate("", "Patch %1 deactivated").arg(patch);
+        body = qApp->translate("", "Patch %1 deactivated.").arg(patch);
         if (getToggleServices()) {
             body.append( ", " );
-            body.append( qApp->translate("", "some service should be restarted.") );
+            body.append( qApp->translate("", "some service(s) should be restarted.") );
             notification.setHintValue("icon", "icon-lock-warning");
         } else {
             body.append( "." );
@@ -262,7 +262,7 @@ void PatchManagerObject::notify(const QString &patch, NotifyAction action)
         break;
     case NotifyActionUpdateAvailable:
         summary = qApp->translate("", "Update available");
-        body = qApp->translate("", "An update for Patch %1 exits.").arg(patch);
+        body = qApp->translate("", "An update for Patch %1 exists.").arg(patch);
 
         remoteActions << Notification::remoteAction(
             QStringLiteral("default"),

--- a/src/bin/patchmanager-daemon/patchmanagerobject.cpp
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.cpp
@@ -262,7 +262,7 @@ void PatchManagerObject::notify(const QString &patch, NotifyAction action)
         break;
     case NotifyActionUpdateAvailable:
         summary = qApp->translate("", "Update available");
-        body = qApp->translate("", "An update for Patch %1 exists.").arg(patch);
+        body = qApp->translate("", "An update for Patch %1 is available.").arg(patch);
 
         remoteActions << Notification::remoteAction(
             QStringLiteral("default"),

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -83,7 +83,7 @@ Page {
 
             TextSwitch {
                 id: fixBitSwitch
-                text: qsTranslate("", "Convert Patches between 32 bit and 64 bit")
+                text: qsTranslate("", "Convert Patches between 32-bit and 64-bit")
                 description: qsTranslate("", "Automatically convert lib or lib64 for select paths shown below.")
                 checked: PatchManager.bitnessMangle
                 onClicked: PatchManager.bitnessMangle = !PatchManager.bitnessMangle

--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -1,8 +1,13 @@
 /*
  * Copyright (C) 2013 Lucien XU <sfietkonstantin@free.fr>
  * Copyright (C) 2016 Andrey Kozhevnikov <coderusinbox@gmail.com>
+ * Copyright (c) 2021, Patchmanager for SailfishOS contributors:
+ *                  - olf "Olf0" <https://github.com/Olf0>
+ *                  - Peter G. "nephros" <sailfish@nephros.org>
+ *                  - Vlad G. "b100dian" <https://github.com/b100dian>
  *
- * You may use this file under the terms of the BSD license as follows:
+ * You may use this file under the terms of the 3-clause BSD license,
+ * as follows:
  *
  * "Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -536,7 +536,7 @@
     </message>
     <message>
         <location filename="../src/qml/SettingsPage.qml" line="49"/>
-        <source>Convert Patches between 32 bit and 64 bit</source>
+        <source>Convert Patches between 32-bit and 64-bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -439,13 +439,13 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="235"/>
-        <source>Patch %1 activated</source>
+        <source>Patch %1 activated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="238"/>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="249"/>
-        <source>some service should be restarted.</source>
+        <source>some service(s) should be restarted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -455,7 +455,7 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="247"/>
-        <source>Patch %1 deactivated</source>
+        <source>Patch %1 deactivated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -485,7 +485,7 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="265"/>
-        <source>An update for Patch %1 exits.</source>
+        <source>An update for Patch %1 exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -485,7 +485,7 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="265"/>
-        <source>An update for Patch %1 exists.</source>
+        <source>An update for Patch %1 is available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -4,88 +4,88 @@
 <context>
     <name></name>
     <message>
-        <location filename="../src/bin/dialog/dialog.qml" line="28"/>
-        <location filename="../src/bin/dialog/dialog.qml" line="45"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="63"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="80"/>
         <source>Activate all Patches marked active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/dialog/dialog.qml" line="53"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="88"/>
         <source>Patchmanager will activate all Patches marked active in 10 seconds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/dialog/dialog.qml" line="66"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="101"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/dialog/dialog.qml" line="136"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="171"/>
         <source>Successfully activated all Patches marked active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/dialog/dialog.qml" line="137"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="172"/>
         <source>Failed to activate all Patches marked active!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="49"/>
-        <location filename="../src/qml/PatchManagerPage.qml" line="142"/>
+        <location filename="../src/qml/AboutPage.qml" line="54"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="147"/>
         <source>About Patchmanager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="222"/>
-        <location filename="../src/bin/dialog/dialog.qml" line="165"/>
-        <location filename="../src/qml/AboutPage.qml" line="63"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="200"/>
+        <location filename="../src/qml/AboutPage.qml" line="68"/>
         <location filename="../src/qml/RestartServicesDialog.qml" line="78"/>
         <source>Patchmanager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="71"/>
+        <location filename="../src/qml/AboutPage.qml" line="76"/>
         <source>Version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="82"/>
+        <location filename="../src/qml/AboutPage.qml" line="87"/>
         <source>Patchmanager allows to automatically modify system files via Patches. It provides a daemon which performs the activation of Patches, plus a GUI to configure these operations and to install or remove Patches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="96"/>
+        <location filename="../src/qml/AboutPage.qml" line="101"/>
         <source>Licensed under the terms of the&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;BSD 3-Clause License&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="106"/>
+        <location filename="../src/qml/AboutPage.qml" line="111"/>
         <source>Sources and Issue Tracker&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;on GitHub&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="123"/>
+        <location filename="../src/qml/AboutPage.qml" line="128"/>
         <source>Credits and Acknowledgements&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;Developers&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="148"/>
+        <location filename="../src/qml/AboutPage.qml" line="153"/>
         <location filename="../src/qml/UnifiedPatchPage.qml" line="210"/>
         <source>Donations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="160"/>
+        <location filename="../src/qml/AboutPage.qml" line="165"/>
         <source>If you appreciate our work, please consider a donation to help covering the hosting costs for Openrepos. Openrepos is critical infrastructure specifically for Patchmanager, because its Web Catalog of Patches is hosted there.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="181"/>
+        <location filename="../src/qml/AboutPage.qml" line="186"/>
         <source>If for some reason you cannot donate to Openrepos, we also appreciate donating to the Free Software Foundation Europe (FSFE).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="246"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="251"/>
         <source>Donate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -206,90 +206,90 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="147"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="152"/>
         <source>Deactivate all Patches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="153"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="158"/>
         <source>Start Patchmanager's daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="159"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="164"/>
         <source>Updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="159"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="164"/>
         <location filename="../src/qml/WebCatalogPage.qml" line="101"/>
         <source>Web Catalog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="165"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="170"/>
         <source>Restart preloaded services</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="171"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="176"/>
         <source>Resolve failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="178"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="183"/>
         <source>Installed Patches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="357"/>
-        <location filename="../src/qml/WebPatchPage.qml" line="333"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="362"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="338"/>
         <source>This Patch is incompatible with the installed SailfishOS version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="365"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="370"/>
         <source>Removing Patch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="470"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="475"/>
         <source>Compatible with:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="485"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="490"/>
         <source>May conflict with another Patch, see %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="486"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="491"/>
         <source>May conflict with %2 other Patches, see %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="490"/>
-        <location filename="../src/qml/WebPatchPage.qml" line="85"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="495"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="90"/>
         <source>Patch details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="494"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="499"/>
         <source>Deactivate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="494"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="499"/>
         <source>Activate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="499"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="504"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="513"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="518"/>
         <location filename="../src/qml/WebCatalogPage.qml" line="248"/>
         <source>No Patches available</source>
         <translation type="unfinished"></translation>
@@ -326,7 +326,7 @@
     </message>
     <message>
         <location filename="../src/qml/ScreenshotsPage.qml" line="71"/>
-        <location filename="../src/qml/WebPatchPage.qml" line="272"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="277"/>
         <source>Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
@@ -376,12 +376,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="75"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="80"/>
         <source>Fetching Patch data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="75"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="80"/>
         <source>Failed to fetch Patch data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -392,43 +392,43 @@
     </message>
     <message>
         <location filename="../src/qml/UnifiedPatchPage.qml" line="185"/>
-        <location filename="../src/qml/WebPatchPage.qml" line="204"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="209"/>
         <source>Links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="225"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="230"/>
         <source>Open discussion link</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/qml/UnifiedPatchPage.qml" line="203"/>
-        <location filename="../src/qml/WebPatchPage.qml" line="267"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="272"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="318"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="323"/>
         <source>Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="335"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="340"/>
         <source>Install Patch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="388"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="393"/>
         <source>[installed]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="388"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="393"/>
         <source>[click to install]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="404"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="409"/>
         <source>Compatible: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -490,57 +490,57 @@
     </message>
     <message>
         <location filename="../src/qml/PatchManagerPage.qml" line="137"/>
-        <location filename="../src/qml/SettingsPage.qml" line="16"/>
+        <location filename="../src/qml/SettingsPage.qml" line="53"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="19"/>
+        <location filename="../src/qml/SettingsPage.qml" line="56"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="22"/>
+        <location filename="../src/qml/SettingsPage.qml" line="59"/>
         <source>Show notification on success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="23"/>
+        <location filename="../src/qml/SettingsPage.qml" line="60"/>
         <source>If this is off, notifications will only be shown when something went wrong.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="29"/>
+        <location filename="../src/qml/SettingsPage.qml" line="66"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="32"/>
+        <location filename="../src/qml/SettingsPage.qml" line="69"/>
         <source>Activate Patches when booting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="33"/>
+        <location filename="../src/qml/SettingsPage.qml" line="70"/>
         <source>Automatically activate all enabled Patches when SailfishOS starts.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="40"/>
+        <location filename="../src/qml/SettingsPage.qml" line="77"/>
         <source>Allow incompatible Patches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="41"/>
+        <location filename="../src/qml/SettingsPage.qml" line="78"/>
         <source>Enable activating Patches, which are not marked as compatible with the installed SailfishOS version. Note that Patches, which are actually incompatible, will not work.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="49"/>
+        <location filename="../src/qml/SettingsPage.qml" line="86"/>
         <source>Convert Patches between 32-bit and 64-bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="50"/>
+        <location filename="../src/qml/SettingsPage.qml" line="87"/>
         <source>Automatically convert lib or lib64 for select paths shown below.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -548,78 +548,78 @@
 <context>
     <name>Sections</name>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="50"/>
+        <location filename="../src/qml/patchmanager.cpp" line="55"/>
         <source>browser</source>
         <translation>Browser</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="51"/>
+        <location filename="../src/qml/patchmanager.cpp" line="56"/>
         <source>camera</source>
         <translation>Camera</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="52"/>
+        <location filename="../src/qml/patchmanager.cpp" line="57"/>
         <source>calendar</source>
         <translation>Calendar</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="53"/>
+        <location filename="../src/qml/patchmanager.cpp" line="58"/>
         <source>clock</source>
         <translation>Clock</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="54"/>
+        <location filename="../src/qml/patchmanager.cpp" line="59"/>
         <source>contacts</source>
         <translation>Contacts</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="55"/>
+        <location filename="../src/qml/patchmanager.cpp" line="60"/>
         <source>email</source>
         <translation>Email</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="56"/>
+        <location filename="../src/qml/patchmanager.cpp" line="61"/>
         <source>gallery</source>
         <translation>Gallery</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="57"/>
+        <location filename="../src/qml/patchmanager.cpp" line="62"/>
         <source>homescreen</source>
         <translation>Homescreen</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="58"/>
+        <location filename="../src/qml/patchmanager.cpp" line="63"/>
         <source>media</source>
         <translation>Media</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="59"/>
+        <location filename="../src/qml/patchmanager.cpp" line="64"/>
         <source>messages</source>
         <translation>Messages</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="60"/>
+        <location filename="../src/qml/patchmanager.cpp" line="65"/>
         <source>phone</source>
         <translation>Phone</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="61"/>
+        <location filename="../src/qml/patchmanager.cpp" line="66"/>
         <source>silica</source>
         <translation>Silica</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="62"/>
+        <location filename="../src/qml/patchmanager.cpp" line="67"/>
         <source>settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="63"/>
-        <location filename="../src/qml/patchmanager.cpp" line="239"/>
+        <location filename="../src/qml/patchmanager.cpp" line="68"/>
+        <location filename="../src/qml/patchmanager.cpp" line="257"/>
         <source>other</source>
         <translation>Other</translation>
     </message>
     <message>
-        <location filename="../src/qml/patchmanager.cpp" line="64"/>
+        <location filename="../src/qml/patchmanager.cpp" line="69"/>
         <source>keyboard</source>
         <translation>Keyboard</translation>
     </message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -450,12 +450,12 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="245"/>
-        <source>Patch deactivated"</source>
+        <source>Patch deactivated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="247"/>
-        <source>Patch %1 deactivated"</source>
+        <source>Patch %1 deactivated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -36,10 +36,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="222"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="283"/>
         <location filename="../src/bin/dialog/dialog.qml" line="200"/>
         <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="78"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="79"/>
         <source>Patchmanager</source>
         <translation type="unfinished"></translation>
     </message>
@@ -222,7 +222,7 @@
     </message>
     <message>
         <location filename="../src/qml/PatchManagerPage.qml" line="164"/>
-        <location filename="../src/qml/WebCatalogPage.qml" line="101"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="106"/>
         <source>Web Catalog</source>
         <translation type="unfinished"></translation>
     </message>
@@ -402,7 +402,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="203"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="208"/>
         <location filename="../src/qml/WebPatchPage.qml" line="272"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -6,12 +6,12 @@
     <message>
         <location filename="../src/bin/dialog/dialog.qml" line="63"/>
         <location filename="../src/bin/dialog/dialog.qml" line="80"/>
-        <source>Activate all Patches marked active</source>
+        <source>Activate all enabled Patches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/bin/dialog/dialog.qml" line="88"/>
-        <source>Patchmanager will activate all Patches marked active in 10 seconds.</source>
+        <source>Patchmanager will start to activate all enabled Patches in 10 seconds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -21,12 +21,12 @@
     </message>
     <message>
         <location filename="../src/bin/dialog/dialog.qml" line="171"/>
-        <source>Successfully activated all Patches marked active.</source>
+        <source>Successfully activated all enabled Patches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/bin/dialog/dialog.qml" line="172"/>
-        <source>Failed to activate all Patches marked active!</source>
+        <source>Failed to activate all enabled Patches!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -90,17 +90,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/DevelopersPage.qml" line="157"/>
+        <location filename="../src/qml/DevelopersPage.qml" line="162"/>
         <source>Developers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/DevelopersPage.qml" line="196"/>
+        <location filename="../src/qml/DevelopersPage.qml" line="201"/>
         <source>%1&apos;s webpage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/DevelopersPage.qml" line="201"/>
+        <location filename="../src/qml/DevelopersPage.qml" line="206"/>
         <source>%1&apos;s %2 account</source>
         <translation type="unfinished"></translation>
     </message>
@@ -290,37 +290,37 @@
     </message>
     <message>
         <location filename="../src/qml/PatchManagerPage.qml" line="518"/>
-        <location filename="../src/qml/WebCatalogPage.qml" line="248"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="253"/>
         <source>No Patches available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="52"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="53"/>
         <source>Restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="58"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="59"/>
         <source>Some services will be restarted now. Reloading the homescreen of the device might take a little time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="62"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="63"/>
         <source>List of services:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="77"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="78"/>
         <source>Note that this will close all apps.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="78"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="79"/>
         <source>Note that this will close %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="81"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="82"/>
         <source>Note that this will close the %1 app.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -331,47 +331,47 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="83"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="88"/>
         <source>Hide search field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="83"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="88"/>
         <source>Show search field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="89"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="94"/>
         <source>Sort by category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="89"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="94"/>
         <source>Sort by date updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="101"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="106"/>
         <source>%1 Patches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="102"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="107"/>
         <source>(by date updated)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="102"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="107"/>
         <source>(by category)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="108"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="113"/>
         <source>Tap to enter search query</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="235"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="240"/>
         <source>Update available: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -386,7 +386,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="188"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="193"/>
         <source>Author: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -433,63 +433,63 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="232"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="234"/>
         <source>Patch activated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="233"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="235"/>
         <source>Patch %1 activated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="236"/>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="247"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="238"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="249"/>
         <source>some service should be restarted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="243"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="245"/>
         <source>Patch deactivated"</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="245"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="247"/>
         <source>Patch %1 deactivated"</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="254"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="256"/>
         <source>Failed to activate Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="255"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="257"/>
         <source>Activating Patch %1 failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="258"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="260"/>
         <source>Failed to deactivate Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="259"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="261"/>
         <source>Deactivating Patch %1 failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="262"/>
-        <source>Update available</source>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="264"/>
+        <source>Update available</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="263"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="265"/>
         <source>An update for Patch %1 exits.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="137"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="142"/>
         <location filename="../src/qml/SettingsPage.qml" line="53"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -70,7 +70,7 @@
     </message>
     <message>
         <location filename="../src/qml/AboutPage.qml" line="153"/>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="210"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="215"/>
         <source>Donations</source>
         <translation type="unfinished"></translation>
     </message>
@@ -105,103 +105,103 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="48"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="53"/>
         <source>Copied log to clipboard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="65"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="70"/>
         <source>Activating Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="67"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="72"/>
         <source>Deactivate Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="68"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="73"/>
         <source>Activate Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="75"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="80"/>
         <source>Remove Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="78"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="83"/>
         <source>Patch %1 removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="85"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="90"/>
         <source>Start Patchmanager's daemon before activating Patches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="107"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="112"/>
         <source>This Patch is not available anymore. You will not be able to reinstall it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="116"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="121"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="116"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="121"/>
         <source>Maintainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="120"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="125"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="121"/>
         <location filename="../src/qml/UnifiedPatchPage.qml" line="126"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="131"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="125"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="130"/>
         <source>Compatible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="137"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="142"/>
         <source>May conflict with:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="165"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="170"/>
         <source>This Patch uses the legacy format for its patch.json file. If you are its maintainer, please do consider updating to the new format; if you are using the Web Catalog you shall not include a patch.json file in your upload!&lt;br /&gt;See the developer section in the &lt;a href=&quot;%1&quot;&gt;README&lt;/a&gt; for details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="171"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="176"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="196"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="201"/>
         <source>Discussion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="253"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="258"/>
         <source>Patch log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="262"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="267"/>
         <source>Press and hold to copy log to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="275"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="280"/>
         <source>No log exists yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -391,7 +391,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="185"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="190"/>
         <location filename="../src/qml/WebPatchPage.qml" line="209"/>
         <source>Links</source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
…, see https://github.com/sailfishos-patches/patchmanager/wiki/Terms-and-wording#0---9

And check all and adapt all but one line numbers in translations/settings-patchmanager.ts, including …
fix quite some line number references being broken for long.