### PR TITLE
pm_apply: Do not quote "+" for BREs

### DIFF
--- a/src/tools/pm_apply
+++ b/src/tools/pm_apply
@@ -118,7 +118,7 @@ mangle_libpath() {
         failure
       fi
       # append at the front so ';' can be easily used for separation 
-      sedcmd="s@^+++ \([^/]*\)$p@+++ \1$pr@;s@^--- \([^/]*\)$p@--- \1$pr@;$sedcmd"
+      sedcmd="s@^+++ \([^/]*\)$p@+++ \1$pr@g;s@^--- \([^/]*\)$p@--- \1$pr@g;$sedcmd"
     done
 
     if [ $found -eq 0 ]; then

--- a/src/tools/pm_apply
+++ b/src/tools/pm_apply
@@ -101,7 +101,7 @@ mangle_libpath() {
     sedcmd=""
     # look for lines to convert, if some are found add pattern to sed scriptlet
     for p in $candidates; do
-      cand_lines=$(grep -c "^\+\+\+ [^/]*$p" "$PATCH_PATH")
+      cand_lines=$(grep -c "^+++ [^/]*$p" "$PATCH_PATH")
       if [ $cand_lines -eq 0 ]; then
         continue  # nothing found, try next
       fi
@@ -118,7 +118,7 @@ mangle_libpath() {
         failure
       fi
       # append at the front so ';' can be easily used for separation 
-      sedcmd="s@^\+\+\+ \([^/]*\)$p@+++ \1$pr@;s@^--- \([^/]*\)$p@--- \1$pr@;$sedcmd"
+      sedcmd="s@^+++ \([^/]*\)$p@+++ \1$pr@;s@^--- \([^/]*\)$p@--- \1$pr@;$sedcmd"
     done
 
     if [ $found -eq 0 ]; then


### PR DESCRIPTION
* Do not quote "+" in BREs, because BREs are the default for grep and sed (see their man-pages) and in BREs the "+" character has no special meaning, plus https://www.gnu.org/software/sed/manual/sed.html#BRE-vs-ERE

* Replace all occurrences of each path pattern with its replacement pattern, instead of only the first occurrence of each path pattern.