### PR TITLE
PatchmanagerPage: Reorder pulley menu entries

### DIFF
--- a/src/qml/PatchManagerPage.qml
+++ b/src/qml/PatchManagerPage.qml
@@ -139,8 +139,9 @@ Page {
             busy: view.busy
             enabled: !busy
             MenuItem {
-                text: qsTranslate("", "Settings")
-                onClicked: pageStack.push(Qt.resolvedUrl("SettingsPage.qml"))
+                text: qsTranslate("", "Deactivate all Patches")
+                onClicked: menuRemorse.execute( text, function() { PatchManager.call(PatchManager.unapplyAllPatches()) } )
+                visible: PatchManager.loaded
             }
 
             MenuItem {
@@ -149,9 +150,8 @@ Page {
             }
 
             MenuItem {
-                text: qsTranslate("", "Deactivate all Patches")
-                onClicked: menuRemorse.execute( text, function() { PatchManager.call(PatchManager.unapplyAllPatches()) } )
-                visible: PatchManager.loaded
+                text: qsTranslate("", "Settings")
+                onClicked: pageStack.push(Qt.resolvedUrl("SettingsPage.qml"))
             }
 
             MenuItem {

--- a/src/qml/PatchManagerPage.qml
+++ b/src/qml/PatchManagerPage.qml
@@ -138,11 +138,16 @@ Page {
         PullDownMenu {
             busy: view.busy
             enabled: !busy
+            
+            /*
+            Disabled due to discussion at https://github.com/sailfishos-patches/patchmanager/pull/272#issuecomment-1047685536
+            
             MenuItem {
                 text: qsTranslate("", "Deactivate all Patches")
                 onClicked: menuRemorse.execute( text, function() { PatchManager.call(PatchManager.unapplyAllPatches()) } )
                 visible: PatchManager.loaded
             }
+            */
 
             MenuItem {
                 text: qsTranslate("", "About Patchmanager")


### PR DESCRIPTION
… "Settings" shall be below "About" and easier to reach, plus "Deactivate all Patches" the hardest to reach (i.e., topmost)