### PR TITLE
[UI] Allow "Unapply All" menu entry through settings

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -22,6 +22,7 @@ Requires:   patch
 Requires:   grep
 Requires:   sed
 Requires:   sailfish-version >= 3.4.0
+Requires:   qml(Nemo.Configuration)
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Qml)

--- a/src/qml/PatchManagerPage.qml
+++ b/src/qml/PatchManagerPage.qml
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013 Lucien XU <sfietkonstantin@free.fr>
  * Copyright (C) 2016 Andrey Kozhevnikov <coderusinbox@gmail.com>
- * Copyright (c) 2021, Patchmanager for SailfishOS contributors:
+ * Copyright (c) 2021, 2022, Patchmanager for SailfishOS contributors:
  *                  - olf "Olf0" <https://github.com/Olf0>
  *                  - Peter G. "nephros" <sailfish@nephros.org>
  *                  - Vlad G. "b100dian" <https://github.com/b100dian>
@@ -37,10 +37,25 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
+import Nemo.Configuration 1.0
 import org.SfietKonstantin.patchmanager 2.0
 
 Page {
     id: container
+
+    /*
+     * usually config values are set through the patchmanager plugin on the
+     * daemon which stores in /etc/patchmanager2.conf.
+     * this config group is for UI settings which do not affect PM behaviour
+     * and thus need not be managed there.
+    */
+    ConfigurationGroup {
+        id: uisettings
+        path: "/org/SfietKonstantin/patchmanager/uisettings"
+
+        property bool showUnapplyAll: false
+    }
+
 
     Timer {
         id : startTimer
@@ -141,13 +156,13 @@ Page {
 
             /*
             Disabled due to discussion at https://github.com/sailfishos-patches/patchmanager/pull/272#issuecomment-1047685536
+            */
 
             MenuItem {
                 text: qsTranslate("", "Deactivate all Patches")
                 onClicked: menuRemorse.execute( text, function() { PatchManager.call(PatchManager.unapplyAllPatches()) } )
-                visible: PatchManager.loaded
+                visible: uisettings.showUnapplyAll
             }
-            */
 
             MenuItem {
                 text: qsTranslate("", "About Patchmanager")

--- a/src/qml/PatchManagerPage.qml
+++ b/src/qml/PatchManagerPage.qml
@@ -138,10 +138,10 @@ Page {
         PullDownMenu {
             busy: view.busy
             enabled: !busy
-            
+
             /*
             Disabled due to discussion at https://github.com/sailfishos-patches/patchmanager/pull/272#issuecomment-1047685536
-            
+
             MenuItem {
                 text: qsTranslate("", "Deactivate all Patches")
                 onClicked: menuRemorse.execute( text, function() { PatchManager.call(PatchManager.unapplyAllPatches()) } )

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2013 Lucien XU <sfietkonstantin@free.fr>
  * Copyright (C) 2016 Andrey Kozhevnikov <coderusinbox@gmail.com>
- * Copyright (c) 2021, Patchmanager for SailfishOS contributors:
+ * Copyright (c) 2021, 2022, Patchmanager for SailfishOS contributors:
  *                  - olf "Olf0" <https://github.com/Olf0>
  *                  - Peter G. "nephros" <sailfish@nephros.org>
  *                  - Vlad G. "b100dian" <https://github.com/b100dian>
@@ -37,9 +37,24 @@
 
 import QtQuick 2.0
 import Sailfish.Silica 1.0
+import Nemo.Configuration 1.0
 import org.SfietKonstantin.patchmanager 2.0
 
 Page {
+
+    /*
+     * usually config values are set through the patchmanager plugin on the
+     * daemon which stores in /etc/patchmanager2.conf.
+     * this config group is for UI settings which do not affect PM behaviour
+     * and thus need not be managed there.
+    */
+    ConfigurationGroup {
+        id: uisettings
+        path: "/org/SfietKonstantin/patchmanager/uisettings"
+
+        property bool showUnapplyAll: false
+    }
+
     SilicaFlickable {
         id: flick
         anchors.fill: parent
@@ -70,6 +85,14 @@ Page {
                 description: qsTranslate("", "Automatically activate all enabled Patches when SailfishOS starts.")
                 checked: PatchManager.applyOnBoot
                 onClicked: PatchManager.applyOnBoot = !PatchManager.applyOnBoot
+                automaticCheck: false
+            }
+
+            TextSwitch {
+                text: qsTranslate("", "Show 'Deactivate all Patches' menu")
+                description: qsTranslate("", "Temporarily enable the menu option to deactivate all Patches.")
+                checked: uisettings.showUnapplyAll
+                onClicked: uisettings.showUnapplyAll = !uisettings.showUnapplyAll
                 automaticCheck: false
             }
 


### PR DESCRIPTION
Follow up on  #272, more precisely https://github.com/sailfishos-patches/patchmanager/pull/272#issuecomment-1047685536

Proposing this in draft mode for now.

1. Do we want the menu option back  (I know I do use it occasionally but will be happy to maintain my private version of this is nothing for mainline PM).
2. This introduces a DConf value to be saved per-user. While this is normal for sailfish apps to do, it; s a first for PM. Up until now all tunables were going form the UI -> Plugin -> Daemon -> `/etc/patchmanager2.conf`.  
This configuration value does not need to go through the daemon, as it doesn't need to know about it, it's UI-only. Also, that makes it multi-user ;)
