### PR TITLE
spec file: Add `Requires: %{name}` to subpackage

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -46,11 +46,12 @@ Requires:   %{name}
 Requires:   libsailfishapp-launcher
 
 %description testcases
-The package patchmanager-testcases installs a small test application and a couple of
-Patches which are helpful for testing the internal functioning of Patchmanager, e.g.,
-when changes were made to it.
-Note that utilising these test cases requires a thorough understanding how Patchmanager
-internally works and hence is most likely only useful for developers.
+The package patchmanager-testcases installs a small test application and a
+couple of Patches which are helpful for testing the internal functioning of
+Patchmanager, e.g., when changes were made to it.
+Note that utilising these test cases requires a thorough understanding how
+Patchmanager internally works and hence is most likely only useful for
+developers.
 
 # This description section includes metadata for SailfishOS:Chum, see
 # https://github.com/sailfishos-chum/main/blob/main/Metadata.md

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -39,10 +39,11 @@ BuildRequires:  pkgconfig(rpm)
 BuildRequires:  pkgconfig(popt)
 
 %package testcases
-Summary: Provides test cases for Patchmanager
-Group: Development
-BuildArch: noarch
-Requires: libsailfishapp-launcher
+Summary:    Provides test cases for Patchmanager
+Group:      Development
+BuildArch:  noarch
+Requires:   %{name}
+Requires:   libsailfishapp-launcher
 
 %description testcases
 The package patchmanager-testcases installs a small test application and a couple of


### PR DESCRIPTION
… `testcases`, because they do depend on Patchmanager to run.