### PR TITLE
[web catalog  migration] define compile-time variables in .spec

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -14,9 +14,9 @@
 # CATALOG_URL SERVER_URL "/" API_PATH
 # MEDIA_URL   SERVER_URL "/" MEDIA_PATH
 
-%define catalog_server https://coderus.openrepos.net
-%define catalog_api_uri pm2/api
-%define catalog_defines SERVER_URL=%{catalog_server} API_PATH=%{catalog_api_uri}
+%global catalog_server https://coderus.openrepos.net
+%global catalog_api_uri pm2/api
+%define catalog_defines -DSERVER_URL=%{catalog_server} -DAPI_PATH=%{catalog_api_uri}
 
 Name:       patchmanager
 
@@ -127,7 +127,7 @@ Url:
 %build
 
 %qtc_qmake5 "PROJECT_PACKAGE_VERSION=%{version}"
-%qtc_make %{?_smp_mflags} %{catalog_defines}
+%qtc_make %{?_smp_mflags} EXTRA_CFLAGS="$CFLAGS %{catalog_defines}"
 
 
 %install

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -13,7 +13,7 @@
 # CATALOG_URL SERVER_URL "/" API_PATH
 %global catalog_server https://coderus.openrepos.net
 %global catalog_api_uri pm2/api
-%define catalog_defines -DSERVER_URL=%{catalog_server} -DAPI_PATH=%{catalog_api_uri}
+%global catalog_defines -DSERVER_URL=%{catalog_server} -DAPI_PATH=%{catalog_api_uri}
 
 Name:       patchmanager
 

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -5,15 +5,12 @@
 %{!?qtc_make:%define qtc_make make}
 %{!?qmake5_install:%define qmake5_install make install INSTALL_ROOT=%{buildroot}}
 
-# override defines:
-# defined in src/bin/patchmanager-daemon/patchmanagerobject.h
-#            src/qml/webcatalog.h:
-#
+# Override these defines in both (!):
+# - src/bin/patchmanager-daemon/patchmanagerobject.h
+# - src/qml/webcatalog.h
 # SERVER_URL  "https://coderus.openrepos.net"
 # API_PATH    "pm2/api"
 # CATALOG_URL SERVER_URL "/" API_PATH
-# MEDIA_URL   SERVER_URL "/" MEDIA_PATH
-
 %global catalog_server https://coderus.openrepos.net
 %global catalog_api_uri pm2/api
 %define catalog_defines -DSERVER_URL=%{catalog_server} -DAPI_PATH=%{catalog_api_uri}

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -5,6 +5,19 @@
 %{!?qtc_make:%define qtc_make make}
 %{!?qmake5_install:%define qmake5_install make install INSTALL_ROOT=%{buildroot}}
 
+# override defines:
+# defined in src/bin/patchmanager-daemon/patchmanagerobject.h
+#            src/qml/webcatalog.h:
+#
+# SERVER_URL  "https://coderus.openrepos.net"
+# API_PATH    "pm2/api"
+# CATALOG_URL SERVER_URL "/" API_PATH
+# MEDIA_URL   SERVER_URL "/" MEDIA_PATH
+
+%define catalog_server https://coderus.openrepos.net
+%define catalog_api_uri pm2/api
+%define catalog_defines SERVER_URL=%{catalog_server} API_PATH=%{catalog_api_uri}
+
 Name:       patchmanager
 
 Summary:    Allows to manage Patches for SailfishOS
@@ -114,7 +127,7 @@ Url:
 %build
 
 %qtc_qmake5 "PROJECT_PACKAGE_VERSION=%{version}"
-%qtc_make %{?_smp_mflags}
+%qtc_make %{?_smp_mflags} %{catalog_defines}
 
 
 %install


### PR DESCRIPTION
To prepare for a possible move of the Web Catalog infrastructure, make the core variables configurable/defined in the .spec file