### PR TITLE
Allow re-installation of installed patches from Web Catalog page

### DIFF
--- a/src/qml/WebPatchPage.qml
+++ b/src/qml/WebPatchPage.qml
@@ -340,7 +340,7 @@ Page {
                         } else if (!fileDelegate.isInstalled) {
                             remorseAction(qsTranslate("", "Install Patch %1").arg(patchData.display_name), installPatch)
                         } else if (fileDelegate.isReinstallable) {
-                            remorseAction(qsTranslate("", "Re-Installing Patch %1").arg(patchData.display_name), installPatch)
+                            remorseAction(qsTranslate("", "Re-Install Patch %1").arg(patchData.display_name), installPatch)
                         }
                     }
 

--- a/src/qml/WebPatchPage.qml
+++ b/src/qml/WebPatchPage.qml
@@ -409,7 +409,8 @@ Page {
 
                         Label {
                             width: parent.width
-                            text: qsTranslate("", "Compatible: %1").arg(modelData.compatible.join(", "))
+                            text: Theme.highlightText(qsTranslate("", "Compatible: %1").arg(modelData.compatible.join(", ")),PatchManager.osVersion, Theme.primaryColor)
+                            textFormat: Text.StyledText
                             font.pixelSize: Theme.fontSizeExtraSmall
                             color: fileDelegate.isCompatible ? Theme.highlightColor : Qt.tint(Theme.highlightColor, "red")
                             wrapMode: Text.WrapAtWordBoundaryOrAnywhere

--- a/src/qml/WebPatchPage.qml
+++ b/src/qml/WebPatchPage.qml
@@ -393,7 +393,12 @@ Page {
                                     verticalCenter: parent.verticalCenter
                                 }
                                 color: Theme.highlightColor
-                                text: fileDelegate.isInstalled ? ( fileDelegate.isReinstallable ? qsTranslate("", "[click to re-install]") : qsTranslate("", "[installed]") ) : qsTranslate("", "[click to install]")
+                                text: fileDelegate.isInstalled
+                                    ? ( fileDelegate.isReinstallable
+                                        ? qsTranslate("", "[click to re-install]")
+                                        : qsTranslate("", "[installed]")
+                                      )
+                                    : qsTranslate("", "[click to install]")
                             }
 
                             Label {

--- a/src/qml/WebPatchPage.qml
+++ b/src/qml/WebPatchPage.qml
@@ -332,12 +332,15 @@ Page {
                     contentHeight: filesContent.height
                     property bool isInstalled: !!container.versions && container.versions[modelData.project] == modelData.version
                     property bool isCompatible: modelData.compatible.indexOf(PatchManager.osVersion) >= 0
+                    property bool isReinstallable: isInstalled && isCompatible
 
                     onClicked: {
                         if (!PatchManager.developerMode && !isCompatible) {
                             errorMessageComponent.createObject(fileDelegate, {text: qsTranslate("", "This Patch is incompatible with the installed SailfishOS version.")})
                         } else if (!fileDelegate.isInstalled) {
                             remorseAction(qsTranslate("", "Install Patch %1").arg(patchData.display_name), installPatch)
+                        } else if (fileDelegate.isReinstallable) {
+                            remorseAction(qsTranslate("", "Re-Installing Patch %1").arg(patchData.display_name), installPatch)
                         }
                     }
 
@@ -390,7 +393,7 @@ Page {
                                     verticalCenter: parent.verticalCenter
                                 }
                                 color: Theme.highlightColor
-                                text: fileDelegate.isInstalled ? qsTranslate("", "[installed]") : qsTranslate("", "[click to install]")
+                                text: fileDelegate.isInstalled ? ( fileDelegate.isReinstallable ? qsTranslate("", "[click to re-install]") : qsTranslate("", "[installed]") ) : qsTranslate("", "[click to install]")
                             }
 
                             Label {


### PR DESCRIPTION
This relaxes/enhances the "can it be installed" checks in the Web Catalog Patch page so installed patches can be installed again.

Use case: lazy patch developers like myself don't bump the patch version when updating OS Compatibility. This results in (old) installed patches shown in red in the main patch list.  
Having the possibility to re-install updates the metadata (at the least), making the red 'incompatible' color go away.

... and a bit of trojan horse commit: highlight the compatible OS version in the "compatible" list.