### PR TITLE
Use modern statements in spec file

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -1,4 +1,4 @@
-%define theme sailfish-default
+%global theme sailfish-default
 
 # These macros should already be defined in the RPMbuild environment, see: rpm --showrc
 %{!?qtc_qmake5:%define qtc_qmake5 %qmake5}
@@ -37,6 +37,7 @@ BuildRequires:  pkgconfig(libshadowutils)
 BuildRequires:  qt5-qttools-linguist
 BuildRequires:  pkgconfig(rpm)
 BuildRequires:  pkgconfig(popt)
+
 
 %package testcases
 Summary:    Provides test cases for Patchmanager
@@ -106,15 +107,17 @@ Url:
 
 
 %prep
-%setup -q -n %{name}-%{version}
+
+%setup -q
+
 
 %build
 
 %qtc_qmake5 "PROJECT_PACKAGE_VERSION=%{version}"
 %qtc_make %{?_smp_mflags}
 
+
 %install
-rm -rf %{buildroot}
 
 %qmake5_install
 
@@ -128,6 +131,7 @@ mkdir -p %{buildroot}/%{_userunitdir}/lipstick.service.wants/
 ln -s ../lipstick-patchmanager.service %{buildroot}/%{_userunitdir}/lipstick.service.wants/
 
 mkdir -p %{buildroot}%{_datadir}/%{name}/patches
+
 
 %pre
 export NO_PM_PRELOAD=1
@@ -157,6 +161,7 @@ case "$1" in
 esac
 exit 0
 
+
 %post
 export NO_PM_PRELOAD=1
 case "$1" in
@@ -184,6 +189,7 @@ systemctl restart dbus-org.SfietKonstantin.patchmanager.service
 systemctl restart checkForUpdates-org.SfietKonstantin.patchmanager.timer
 exit 0
 
+
 %preun
 export NO_PM_PRELOAD=1
 case "$1" in
@@ -200,6 +206,7 @@ case "$1" in
 ;;
 esac
 exit 0
+
 
 %postun
 export NO_PM_PRELOAD=1
@@ -224,6 +231,7 @@ systemctl daemon-reload
 systemctl-user daemon-reload
 exit 0
 
+
 %files testcases
 %defattr(-,root,root,-)
 %{_libdir}/qt5/qml/org/SfietKonstantin/patchmanagertests
@@ -231,6 +239,7 @@ exit 0
 %{_datadir}/applications/patchmanager-testcase.desktop
 %{_datadir}/patchmanager-testcase
 %{_datadir}/patchmanager-test/testfile
+
 
 %files
 %defattr(-,root,root,-)

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -8,7 +8,7 @@
 Name:       patchmanager
 
 Summary:    Allows to manage Patches for SailfishOS
-Version:    3.2.4
+Version:    3.2.5
 Release:    1
 Group:      Qt/Qt
 License:    BSD-3-Clause


### PR DESCRIPTION
- `%global` instead of `%define` for static expressions: `%global`s are evaluated once when set, `%define`s are evaluated each time used.  Plus the scope of `%global`s is all sections, including the scriptlets.
- `-n %{name}-%{version}` always has been the default for `%setup`, hence omitted now.
-  `rm -rf %{buildroot}` as first statement in the `%install` section is long obsolete, thus superfluous.