### PR TITLE
Treat warnings as errors

### DIFF
--- a/patchmanager.pro
+++ b/patchmanager.pro
@@ -1,6 +1,6 @@
+QMAKE_CXXFLAGS += -Werror
 TEMPLATE = subdirs
 SUBDIRS = src tests
-
 OTHER_FILES += rpm/patchmanager.spec
 
 TRANSLATIONS += $$files(translations/settings-$${TARGET}-*.ts)

--- a/src/bin/dialog/dialog.pro
+++ b/src/bin/dialog/dialog.pro
@@ -3,6 +3,7 @@ TARGET = patchmanager-dialog
 
 QT += dbus network
 CONFIG += sailfishapp c++11
+QMAKE_CXXFLAGS += -Werror
 
 dbus.files = dbus/org.SfietKonstantin.patchmanager.service
 dbus.path = /usr/share/dbus-1/services

--- a/src/bin/patchmanager-daemon/patchmanager-daemon.pro
+++ b/src/bin/patchmanager-daemon/patchmanager-daemon.pro
@@ -9,6 +9,7 @@ PKGCONFIG += rpm
 PKGCONFIG += popt
 
 INCLUDEPATH += /usr/include/rpm
+QMAKE_CXXFLAGS += -Werror
 QMAKE_CFLAGS += -fPIE
 QMAKE_CXXFLAGS += -fPIE
 QMAKE_LFLAGS += -pie

--- a/src/preload/preload.pro
+++ b/src/preload/preload.pro
@@ -4,7 +4,7 @@ CONFIG += plugin
 CONFIG += link_pkgconfig
 PKGCONFIG += libshadowutils
 INCLUDEPATH += /usr/include/libshadowutils
-QMAKE_CFLAGS += -std=c11
+QMAKE_CFLAGS += -std=c11 -Werror
 
 LIBS = -ldl
 

--- a/src/qml/qml.pro
+++ b/src/qml/qml.pro
@@ -4,6 +4,7 @@ PLUGIN_IMPORT_PATH = org/SfietKonstantin/patchmanager
 TEMPLATE = lib
 QT = core qml network dbus gui
 CONFIG += qt plugin hide_symbols
+QMAKE_CXXFLAGS += -Werror
 
 HEADERS += \
     patchmanager.h \


### PR DESCRIPTION
Since warnings seem to be gone, let's keep it this way.

(I converted a file with dos2unix, so you might need to append `?w=1` to the diff url)