### PR TITLE
Developer Mode: allow to jump to Patch Project page

### DIFF
--- a/src/qml/WebPatchPage.qml
+++ b/src/qml/WebPatchPage.qml
@@ -80,6 +80,15 @@ Page {
             text: fetching ? qsTranslate("", "Fetching patch data") : qsTranslate("", "Failed to fetch Patch data")
         }
 
+        PullDownMenu {
+                visible: PatchManager.developerMode
+                MenuItem {
+                    text: qsTranslate("", "Open Project Page")
+                    // FIXME: do not hardcode location:
+                    onClicked: Qt.openUrlExternally("https://coderus.openrepos.net/pm2/project/" + patchData.name)
+                }
+        }
+
         Column {
             id: content
             width: parent.width

--- a/src/qml/WebPatchPage.qml
+++ b/src/qml/WebPatchPage.qml
@@ -81,7 +81,7 @@ Page {
         }
 
         PullDownMenu {
-                visible: PatchManager.developerMode
+                visible: PatchManager.patchDevelMode
                 MenuItem {
                     text: qsTranslate("", "Open Project Page")
                     // FIXME: do not hardcode location:


### PR DESCRIPTION
Add a pulley menu to the Patch page of a Web Catalog entry.
Allows developers to quickly access the Web Catalog, i.e. to change some information on the given patch.

Toggled by developer mode.