### PR TITLE
Really stick to new nomenclature, plus …

### DIFF
--- a/.github/workflows/ci_sfos3.4.0-armv7hl.yml
+++ b/.github/workflows/ci_sfos3.4.0-armv7hl.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     env:
-      SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/src/bin/patchmanager-daemon/main.cpp
+++ b/src/bin/patchmanager-daemon/main.cpp
@@ -53,11 +53,11 @@ void help()
     std::cout << "patchmanager" << std::endl;
     std::cout << std::endl;
     std::cout << "Usage:" << std::endl;
-    std::cout << "  patchmanager                : Run as daemon" << std::endl;
+    std::cout << "  patchmanager                : Run Patchmanager as daemon" << std::endl;
     std::cout << "  patchmanager -a <Patch>     : Enable and activate a Patch" << std::endl;
     std::cout << "  patchmanager -u <Patch>     : Deactivate and disable (unapply) a Patch" << std::endl;
     std::cout << "  patchmanager --unapply-all  : Deactivate and disable (unapply) all Patches" << std::endl;
-    std::cout << "  patchmanager --daemon       : Daemonize" << std::endl;
+    std::cout << "  patchmanager --daemon       : Daemonize Patchmanager" << std::endl;
 }
 
 int main(int argc, char **argv)

--- a/src/bin/patchmanager-daemon/main.cpp
+++ b/src/bin/patchmanager-daemon/main.cpp
@@ -53,11 +53,11 @@ void help()
     std::cout << "patchmanager" << std::endl;
     std::cout << std::endl;
     std::cout << "Usage:" << std::endl;
-    std::cout << "  patchmanager                : Run Patchmanager as daemon" << std::endl;
+    std::cout << "  patchmanager [--help]       : Print this help text" << std::endl;
     std::cout << "  patchmanager -a <Patch>     : Enable and activate a Patch" << std::endl;
     std::cout << "  patchmanager -u <Patch>     : Deactivate and disable (unapply) a Patch" << std::endl;
     std::cout << "  patchmanager --unapply-all  : Deactivate and disable (unapply) all Patches" << std::endl;
-    std::cout << "  patchmanager --daemon       : Daemonize Patchmanager" << std::endl;
+    std::cout << "  patchmanager --daemon       : Start Patchmanager as daemon" << std::endl;
 }
 
 int main(int argc, char **argv)

--- a/src/bin/patchmanager-daemon/main.cpp
+++ b/src/bin/patchmanager-daemon/main.cpp
@@ -1,8 +1,13 @@
 /*
  * Copyright (C) 2013 Lucien XU <sfietkonstantin@free.fr>
  * Copyright (C) 2016 Andrey Kozhevnikov <coderusinbox@gmail.com>
+ * Copyright (c) 2021, Patchmanager for SailfishOS contributors:
+ *                  - olf "Olf0" <https://github.com/Olf0>
+ *                  - Peter G. "nephros" <sailfish@nephros.org>
+ *                  - Vlad G. "b100dian" <https://github.com/b100dian>
  *
- * You may use this file under the terms of the BSD license as follows:
+ * You may use this file under the terms of the 3-clause BSD license,
+ * as follows:
  *
  * "Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -48,11 +53,11 @@ void help()
     std::cout << "patchmanager" << std::endl;
     std::cout << std::endl;
     std::cout << "Usage:" << std::endl;
-    std::cout << "  patchmanager                : run as daemon" << std::endl;
-    std::cout << "  patchmanager -a <patch>     : apply a patch" << std::endl;
-    std::cout << "  patchmanager -u <patch>     : unapply a patch" << std::endl;
-    std::cout << "  patchmanager --unapply-all  : unapply all patches" << std::endl;
-    std::cout << "  patchmanager --daemon       : daemonize" << std::endl;
+    std::cout << "  patchmanager                : Run as daemon" << std::endl;
+    std::cout << "  patchmanager -a <Patch>     : Enable and activate a Patch" << std::endl;
+    std::cout << "  patchmanager -u <Patch>     : Deactivate and disable (unapply) a Patch" << std::endl;
+    std::cout << "  patchmanager --unapply-all  : Deactivate and disable (unapply) all Patches" << std::endl;
+    std::cout << "  patchmanager --daemon       : Daemonize" << std::endl;
 }
 
 int main(int argc, char **argv)

--- a/src/bin/patchmanager-daemon/patch/patch.json
+++ b/src/bin/patchmanager-daemon/patch/patch.json
@@ -1,6 +1,6 @@
 {
-    "name": 'Deactivate and disable ("unapply") all Patches on upgrade',
-    "description": 'Patch for "unapplying" all Patches when upgrading SailfishOS.  Do not "unapply" this Patch manually, unless you want to remove ("uninstall") Patchmanager completely.',
+    "name": "Deactivate and disable (unapply) all Patches on upgrade",
+    "description": "Patch for unapplying all Patches when upgrading SailfishOS.  Do not unapply this Patch manually, unless you want to remove (uninstall) Patchmanager completely.",
     "category": "settings",
     "infos": {
         "maintainer": "coderus"

--- a/src/bin/patchmanager-daemon/patch/patch.json
+++ b/src/bin/patchmanager-daemon/patch/patch.json
@@ -1,6 +1,6 @@
 {
-    "name": "Unapply all patches on Upgrade",
-    "description": "Patch for unapplying all patches when upgrading SailfishOS version. Do not unapply this patch manually, unless you want to completely uninstall Patchmanager.",
+    "name": 'Deactivate and disable ("unapply") all Patches on upgrade',
+    "description": 'Patch for "unapplying" all Patches when upgrading SailfishOS.  Do not "unapply" this Patch manually, unless you want to remove ("uninstall") Patchmanager completely.',
     "category": "settings",
     "infos": {
         "maintainer": "coderus"

--- a/src/bin/patchmanager-daemon/patchmanagerobject.cpp
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.cpp
@@ -1374,7 +1374,7 @@ void PatchManagerObject::lipstickChanged(const QString &state)
     qDebug() << Q_FUNC_INFO << state;
 
     if (!getLoaded() && !m_failed && !getSettings(QStringLiteral("applyOnBoot"), false).toBool()) {
-        qDebug() << Q_FUNC_INFO << "Automatically activate all enabled Patches when SailfishOS boots.";
+        qDebug() << Q_FUNC_INFO << "Automatically activate all enabled Patches when SailfishOS starts.";
         QTimer::singleShot(20000, this, [this](){
             QDBusMessage showPatcher = QDBusMessage::createMethodCall(QStringLiteral("org.SfietKonstantin.patchmanager"),
                                                                       QStringLiteral("/"),

--- a/src/bin/patchmanager-daemon/patchmanagerobject.cpp
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.cpp
@@ -938,13 +938,19 @@ void PatchManagerObject::process()
 {
     const QStringList args = QCoreApplication::arguments();
 
-    if (args.count() == 2 && args[1] == QStringLiteral("--daemon")) {
-        initialize();
-    } else if (args[1] == QStringLiteral("--reset-system")) {
-         resetSystem();
-         QCoreApplication::exit(2);
-         return;
-    } else if (args.count() > 1) {
+    if (args.count() == 1) {
+        return;  // Prints help text.
+    } else if (args.count() == 2) {
+        if (args[1] == QStringLiteral("--help")) {
+            return;  // Also prints help text.
+        } else if (args[1] == QStringLiteral("--daemon")) {
+            initialize();
+        } else if (args[1] == QStringLiteral("--reset-system")) {
+            resetSystem();
+            QCoreApplication::exit(2);
+            return;
+        }
+    } else if (args.count() > 1) {  // Must be "> 1", not "> 2" for "--unapply-all"
         QDBusConnection connection = QDBusConnection::systemBus();
         qDebug() << Q_FUNC_INFO << "Has arguments, sending D-Bus message and quit.";
 

--- a/src/bin/patchmanager-daemon/patchmanagerobject.cpp
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.cpp
@@ -243,7 +243,7 @@ void PatchManagerObject::notify(const QString &patch, NotifyAction action)
         break;
     case NotifyActionSuccessUnapply:
         summary = qApp->translate("", "Patch deactivated");
-        body = qApp->translate("", "Patch %1 deactivated.").arg(patch);
+        body = qApp->translate("", "Patch %1 is now inactive.").arg(patch);
         if (getToggleServices()) {
             body.append( ", " );
             body.append( qApp->translate("", "some service(s) should be restarted.") );
@@ -333,7 +333,7 @@ void PatchManagerObject::lateInitialize()
 
     QFile file (AUSMT_INSTALLED_LIST_FILE);
     if (file.exists()) {
-        qWarning() << Q_FUNC_INFO << "Found extant AUSMT package list, importing list as Patches marked active.";
+        qWarning() << Q_FUNC_INFO << "Found extant AUSMT package list, importing list as enabled Patches.";
         if (file.open(QFile::ReadOnly)) {
             while (!file.atEnd()) {
                 const QString line = QString::fromLatin1(file.readLine());
@@ -1374,7 +1374,7 @@ void PatchManagerObject::lipstickChanged(const QString &state)
     qDebug() << Q_FUNC_INFO << state;
 
     if (!getLoaded() && !m_failed && !getSettings(QStringLiteral("applyOnBoot"), false).toBool()) {
-        qDebug() << Q_FUNC_INFO << "Automatically activating all Patches marked active after SailfishOS booted.";
+        qDebug() << Q_FUNC_INFO << "Automatically activate all enabled Patches when SailfishOS boots.";
         QTimer::singleShot(20000, this, [this](){
             QDBusMessage showPatcher = QDBusMessage::createMethodCall(QStringLiteral("org.SfietKonstantin.patchmanager"),
                                                                       QStringLiteral("/"),
@@ -1451,10 +1451,10 @@ void PatchManagerObject::onLipstickChanged(const QString &, const QVariantMap &c
     const QString activeState = changedProperties.value(QStringLiteral("ActiveState"), QStringLiteral("unknown")).toString();
     qDebug() << Q_FUNC_INFO << activeState;
     if (activeState == QStringLiteral("failed")) {
-        qInfo() << Q_FUNC_INFO << "Detected lipstick crash, hence deactivating all Patches.";
+        qInfo() << Q_FUNC_INFO << "Detected lipstick crash, hence deactivating and disabling all Patches.";
         unapplyAllPatches();
     } else if (activeState == QStringLiteral("active") && !getLoaded() && !m_failed && !getSettings(QStringLiteral("applyOnBoot"), false).toBool()) {
-        qInfo() << Q_FUNC_INFO << "Automatically activating all Patches marked active.";
+        qInfo() << Q_FUNC_INFO << "Automatically activating all enabled Patches.";
         QTimer::singleShot(5000, this, [this](){
             QDBusMessage showPatcher = QDBusMessage::createMethodCall(QStringLiteral("org.SfietKonstantin.patchmanager"),
                                                                       QStringLiteral("/"),
@@ -1471,7 +1471,7 @@ void PatchManagerObject::onOsUpdateProgress(int progress)
         return;
     }
 
-    qInfo() << Q_FUNC_INFO << "Detected SailfishOS update in progress, hence deactivating all Patches.";
+    qInfo() << Q_FUNC_INFO << "Detected SailfishOS update in progress, hence deactivating and disabling all Patches.";
     unapplyAllPatches();
 }
 

--- a/src/qml/PatchManagerPage.qml
+++ b/src/qml/PatchManagerPage.qml
@@ -159,7 +159,7 @@ Page {
             */
 
             MenuItem {
-                text: qsTranslate("", "Deactivate all Patches")
+                text: qsTranslate("", "Disable and deactivate all Patches")
                 onClicked: menuRemorse.execute( text, function() { PatchManager.call(PatchManager.unapplyAllPatches()) } )
                 visible: uisettings.showUnapplyAll
             }

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -90,7 +90,7 @@ Page {
             }
 
             TextSwitch {
-                text: qsTranslate("", "Activate Patches when booting")
+                text: qsTranslate("", "Activate enabled Patches when booting")
                 description: qsTranslate("", "Automatically activate all enabled Patches when SailfishOS starts.")
                 checked: PatchManager.applyOnBoot
                 onClicked: PatchManager.applyOnBoot = !PatchManager.applyOnBoot
@@ -98,8 +98,8 @@ Page {
             }
 
             TextSwitch {
-                text: qsTranslate("", "Show 'Deactivate all Patches' pulley menu entry")
-                description: qsTranslate("", "Enable an additional pulley menu entry for Patchmanager's main page to deactivate all Patches.")
+                text: qsTranslate("", "Show 'Disable and deactivate all Patches' pulley menu entry")
+                description: qsTranslate("", "Enable an additional pulley menu entry for Patchmanager's main page to disable and deactivate all Patches.")
                 checked: uisettings.showUnapplyAll
                 onClicked: uisettings.showUnapplyAll = !uisettings.showUnapplyAll
                 automaticCheck: false
@@ -114,7 +114,7 @@ Page {
                     left: parent.left
                 }
                 label: qsTranslate("", "Version Check") + ":"
-                description: qsTranslate("", "Enable activating Patches, which are not marked as compatible with the installed SailfishOS version. Note that Patches, which are actually incompatible, will not work.")
+                description: qsTranslate("", "Allows to enable Patches, which are not marked as compatible with the installed SailfishOS version. Note that Patches, which are actually incompatible, will not work.")
                 onCurrentIndexChanged: PatchManager.sfosVersionCheck = currentIndex
                 currentIndex: (PatchManager.sfosVersionCheck) ? PatchManager.sfosVersionCheck : VersionCheck.Strict
                 menu: ContextMenu {

--- a/src/tools/pm_apply
+++ b/src/tools/pm_apply
@@ -78,13 +78,13 @@ test_if_applied() {
   fi
 }
 
-# see issue #71: https://github.com/sailfishos-patches/patchmanager/issues/71
+# For details see issue #71: https://github.com/sailfishos-patches/patchmanager/issues/71
 mangle_libpath() {
   if [ -f "$PATCH_PATH" ]; then
     log
     log "----------------------------------"
-    [ $SYS_BITNESS -eq 32 ] && log "Checking paths for 32->64bit conversion"
-    [ $SYS_BITNESS -eq 64 ] && log "Checking paths for 64->32bit conversion"
+    [ $SYS_BITNESS -eq 32 ] && log "Checking paths for 32-bit --> 64-bit conversion"
+    [ $SYS_BITNESS -eq 64 ] && log "Checking paths for 64-bit --> 32-bit conversion"
     log "----------------------------------"
     log
 
@@ -149,7 +149,7 @@ verify_text_patch() {
   if [ -f "$PATCH_PATH" ]; then
     log
     log "----------------------------------"
-    log "Dry running patch"
+    log "Dry running patch file"
     log "----------------------------------"
     log
 
@@ -164,7 +164,7 @@ install_text_patch() {
   if [ -f "$PATCH_PATH" ]; then
     log
     log "----------------------------------"
-    log "Applying text patch"
+    log "Applying patch file"
     log "----------------------------------"
     log
 
@@ -175,7 +175,7 @@ install_text_patch() {
 create_backup_patch() {
   log
   log "----------------------------------"
-  log "Creating backup patch"
+  log "Creating backup of patch file"
   log "----------------------------------"
   log
 
@@ -202,7 +202,7 @@ log "----------------------------------"
 log
 
 if [ -z "$PARAMETER" ]; then
-  log "ERROR: A parameter must be provided for applying!"
+  log "ERROR: A parameter must be provided for the pm_apply script!"
   failure
 fi
 

--- a/src/tools/pm_unapply
+++ b/src/tools/pm_unapply
@@ -93,7 +93,7 @@ remove_text_patch() {
 clean_backup_patch() {
   log
   log "----------------------------------"
-  log "Deleting Patch backup directory"
+  log "Deleting patch file backup"
   log "----------------------------------"
   log
 

--- a/src/tools/pm_unapply
+++ b/src/tools/pm_unapply
@@ -93,7 +93,7 @@ remove_text_patch() {
 clean_backup_patch() {
   log
   log "----------------------------------"
-  log "Deleting patch file backup"
+  log "Deleting backup of patch file"
   log "----------------------------------"
   log
 

--- a/src/tools/pm_unapply
+++ b/src/tools/pm_unapply
@@ -82,7 +82,7 @@ remove_text_patch() {
   if [ -f "$PATCH_FILE" ]; then
     log
     log "----------------------------------"
-    log "Unapplying text patch"
+    log "Reverting (unapplying) applied patch file"
     log "----------------------------------"
     log
 
@@ -93,7 +93,7 @@ remove_text_patch() {
 clean_backup_patch() {
   log
   log "----------------------------------"
-  log "Cleaning backup patch"
+  log "Deleting Patch backup directory"
   log "----------------------------------"
   log
 
@@ -117,7 +117,7 @@ log "----------------------------------"
 log
 
 if [ -z "$PARAMETER" ]; then
-  log "ERROR: A parameter must be provided for unapplying!"
+  log "ERROR: A parameter must be provided for the pm_unapply script!"
   failure
 fi
 


### PR DESCRIPTION
1. Fix help output in [`src/bin/patchmanager-daemon/main.cpp`, lines 51-61](https://github.com/sailfishos-patches/patchmanager/blob/26eb9bdb175241e6d85562d28b556a852f03aff9/src/bin/patchmanager-daemon/main.cpp#L51-L61).
2. Fix and slightly extend argument evaluation logic in [`src/bin/patchmanager-daemon/patchmanagerobject.cpp`, lines 941-953](https://github.com/sailfishos-patches/patchmanager/blob/26eb9bdb175241e6d85562d28b556a852f03aff9/src/bin/patchmanager-daemon/patchmanagerobject.cpp#L941-L953).
3. For changes due to the new nomenclature, see, e.g., [Patchmanager's Wiki page *Terms-and-wording*, entry *"enable"*](https://github.com/sailfishos-patches/patchmanager/wiki/Terms-and-wording#enable).