### PR TITLE
[spec file] Insert dummy changelog with a correct entry 

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -291,5 +291,5 @@ exit 0
 %{_datadir}/themes/%{theme}/meegotouch/z2.0/icons/*.png
 
 %changelog
-* Thu Sep  9 1999 SailfishOS Patches <sailfishos-patches@users.noreply.github.com> - 9.9.9
-- %{url}/releases
+* Thu Sep  9 1999 SailfishOS Patches <sailfishos-patches@users.noreply.github.com> - 99.99.99
+- See %{url}/releases

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -18,7 +18,7 @@
 Name:       patchmanager
 
 Summary:    Allows to manage Patches for SailfishOS
-Version:    3.2.6
+Version:    3.2.7
 Release:    1
 Group:      Qt/Qt
 License:    BSD-3-Clause
@@ -76,7 +76,7 @@ Categories:
 Custom:
   Repo: %{url}
 Url:
-  Homepage: https://build.sailfishos.org/package/show/sailfishos:chum/%{name}
+  Homepage: https://openrepos.net/content/%{name}/%{name}-testcases
   Help: %{url}/discussions/232
   Bugtracker: %{url}/issues
 %endif
@@ -109,7 +109,7 @@ Custom:
   Repo: %{url}
 Icon: %{url}/raw/master/src/share/patchmanager-big.png
 Url:
-  Homepage: https://openrepos.net/content/patchmanager/%{name}
+  Homepage: https://openrepos.net/content/%{name}/%{name}
   Help: %{url}/blob/master/README.md
   Bugtracker: https://forum.sailfishos.org/t/bugs-in-patchmanager-3-1-0/8552
   Donation: https://openrepos.net/donate
@@ -290,3 +290,6 @@ exit 0
 %{_datadir}/themes/%{theme}/meegotouch/z1.75/icons/*.png
 %{_datadir}/themes/%{theme}/meegotouch/z2.0/icons/*.png
 
+%changelog
+* Thu Sep  9 1999 SailfishOS Patches <sailfishos-patches@users.noreply.github.com> - 9.9.9
+- %{url}/releases

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -293,3 +293,4 @@ exit 0
 %changelog
 * Thu Sep  9 1999 SailfishOS Patches <sailfishos-patches@users.noreply.github.com> - 99.99.99
 - See %{url}/releases
+


### PR DESCRIPTION
… to calm down some versions / configurations of `rpmlint`: Missing `%changelog` section or file is punished with an error, an inconsistent version number only with a warning.

- Update homepages to OpenRepos pages (looks more representative)

- Post release version increase