### PR TITLE
Remove tinting, use Theme error color for compat display

### DIFF
--- a/src/qml/PatchManagerPage.qml
+++ b/src/qml/PatchManagerPage.qml
@@ -500,7 +500,7 @@ Page {
                     Label {
                         text: name
                         color: patchObject.details.isCompatible ? background.down ? Theme.highlightColor : Theme.primaryColor
-                                                                : background.down ? Qt.tint(Theme.highlightColor, "red") : Qt.tint(Theme.primaryColor, "red")
+                                                                : background.down ? Theme.highlightBackgroundFromColor(Theme.errorColor, Theme.colorScheme) : Theme.errorColor
                         truncationMode: TruncationMode.Fade
                     }
                     Row {

--- a/src/qml/WebPatchPage.qml
+++ b/src/qml/WebPatchPage.qml
@@ -426,7 +426,7 @@ Page {
                             text: Theme.highlightText(qsTranslate("", "Compatible: %1").arg(modelData.compatible.join(", ")),PatchManager.osVersion, Theme.primaryColor)
                             textFormat: Text.StyledText
                             font.pixelSize: Theme.fontSizeExtraSmall
-                            color: fileDelegate.isCompatible ? Theme.highlightColor : Qt.tint(Theme.highlightColor, "red")
+                            color: fileDelegate.isCompatible ? Theme.highlightColor : Theme.errorColor
                             wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                         }
 


### PR DESCRIPTION
See: https://github.com/sailfishos-patches/patchmanager/pull/411#discussion_r1096832591

Tinting never did anything but apply the color `"red"`, because `Qt.tint()` wants the second color to be more or less transparent, which `"red"` is not.

`Theme.errorColor` is not as bright and saturated as `"red"` but it matches the system theme.