### PR TITLE
compat check: fix logic for Web Patch (re)install

### DIFF
--- a/src/qml/WebPatchPage.qml
+++ b/src/qml/WebPatchPage.qml
@@ -342,12 +342,13 @@ Page {
                     property bool isInstalled: !!container.versions && container.versions[modelData.project] == modelData.version
                     property bool isCompatible: (modelData.compatible.indexOf(PatchManager.osVersion) >= 0)
                     property bool forceCompatible: PatchManager.sfosVersionCheck !== VersionCheck.Strict
-                    property bool isReinstallable: isInstalled && (isCompatible || forceCompatible)
+                    property bool isInstallable: isCompatible || forceCompatible
+                    property bool isReinstallable: isInstalled && isInstallable
 
                     onClicked: {
                         if (isReinstallable) {
                             remorseAction(qsTranslate("", "Re-Install Patch %1").arg(patchData.display_name), installPatch)
-                        } else if (!isCompatible && !forceCompatible) {
+                        } else if (!isInstallable) {
                             errorMessageComponent.createObject(fileDelegate, {text: qsTranslate("", "This Patch is incompatible with the installed SailfishOS version.")})
                         } else {
                             remorseAction(qsTranslate("", "Install Patch %1").arg(patchData.display_name), installPatch)


### PR DESCRIPTION
Some fallout from #408 

The logic prevents installation of incompatible patches from Web Catalog despite (or in the reverse meaning of) the VersionCheck setting.

At first I attributed this to the migrated settings bug #405, but it's a separate issue.

Please review the logic, could be I missed a case.