### PR TITLE
Set vendor statically to `chum` for all builds …

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -28,6 +28,7 @@ Release:    1
 Group:      Qt/Qt
 License:    BSD-3-Clause
 URL:        https://github.com/sailfishos-patches/%{name}
+Vendor:     chum
 Source0:    %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 # Note that the rpmlintrc file MUST be named exactly so according to
 # https://en.opensuse.org/openSUSE:Packaging_checks#Building_Packages_in_spite_of_errors


### PR DESCRIPTION
…, regardless where they are built, to avoid blocked upgrade paths (as, e.g., observed in [Storeman issue \#406](https://github.com/storeman-developers/harbour-storeman/issues/406#issuecomment-1503913989)) due to [vendor stickiness](https://en.opensuse.org/SDB:Vendor_change_update).