### PR TITLE
Pre release version increase

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -23,7 +23,7 @@
 Name:       patchmanager
 
 Summary:    Allows to manage Patches for SailfishOS
-Version:    3.2.7
+Version:    3.2.9
 Release:    1
 # The Group tag should comprise one of the groups listed here:
 # https://github.com/mer-tools/spectacle/blob/master/data/GROUPS


### PR DESCRIPTION
It looks like 3.2.8 was missed in the spec file!
Rather than reissuing a correct 3.2.8 release, proceed to 3.2.9.

Luckily it looks like this mishap was automagically alleviated by the SailfishOS-OBS, which rewrote the version tag to 3.2.8 (likely based on the git tag)!