### PR TITLE
Post release version increase …

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -23,7 +23,7 @@
 Name:       patchmanager
 
 Summary:    Allows to manage Patches for SailfishOS
-Version:    3.2.9
+Version:    3.2.10
 Release:    1
 # The Group tag should comprise one of the groups listed here:
 # https://github.com/mer-tools/spectacle/blob/master/data/GROUPS


### PR DESCRIPTION
… as it always shall be carried out, but was missed for 3.2.8, which resulted in #434.