### PR TITLE
multi-apply-tool: fix some syntax errors

### DIFF
--- a/src/tools/patchmanager-tool
+++ b/src/tools/patchmanager-tool
@@ -118,8 +118,8 @@ case "$1" in
           exit 0
         fi
       else
-          printf 'Unknown parameter: %s.\nIf you meant to export to a file, use "--export --file %s"\n' "$1" "$1" >&2
-          exit 1
+        printf 'Unknown parameter: %s.\nIf you meant to export to a file, use "--export --file %s"\n' "$1" "$1" >&2
+        exit 1
       fi
     else
       surplus "$*"


### PR DESCRIPTION
It seems the history of #302 ended up in some merge/syntax errors

These are some quick changes to make the script work again.

