### PR TITLE
[patchmanager-tool] Alter option `-h` to `-?`, …

### DIFF
--- a/src/tools/patchmanager-tool
+++ b/src/tools/patchmanager-tool
@@ -11,21 +11,21 @@ called="$(basename $0)"
 function surplus() {
   if [ -n "$*" ]; then
     printf 'Too many parameters: %s\n' "$*" >&2
-    printf 'Call "%s -h" for a help page.\n' "$called" >&2
+    printf 'Call "%s -?" for a help page.\n' "$called" >&2
     exit 1
   fi
 }
 
 function usage() {
   printf "Patchmanager tool is a front-end for the patchmanager executable.\n"
-  printf "USAGE: %s [-a|-A|-d|-D|-e|-h] [<patchlist>|-f <filepath>]\n" "$called"
+  printf "USAGE: %s [-a|-A|-d|-D|-e|-?] [<patchlist>|-f <filepath>]\n" "$called"
   printf "\t-a | --activate\t\t\tActivate / apply Patches from list or file (via -f).\n"
   printf "\t-A | --activate-all\t\tActivate / apply all Patches formerly marked as active.\n"
   printf "\t-d | --deactivate\t\tDeactivate / unapply Patches from list or file (via -f).\n"
   printf "\t-D | --deactivate-all\t\tDeactivate / unapply all Patches.\n"
   printf "\t-f | --file <filepath>\t\tUse <filepath> for the list of Patches.\n"
   printf "\t-e | --export\t\t\tExport list of Patches marked as active either to STDout or (via -f) to a file.\n"
-  printf "\t-h | --help\t\t\tPrint this help.\n"
+  printf "\t-? | --help\t\t\tPrint this help.\n"
   printf "* The <patchlist> must be comprised of (internal) names of Patches, separated by white-spaces, commas or both.\n"
   printf "* For writing to <filepath>, it must not already exist and must be in a writable directory.\n"
   printf "* For reading from <filepath>, it must be a plain text file containing the (internal) names of Patches, separated by white-spaces, commas or both.\n"
@@ -126,20 +126,20 @@ case "$1" in
       exit 0
     fi
   ;;
-  -h|--help)
+  -\?|--help)
     usage
     exit 0
   ;;
   *)
     printf 'Missing or wrong parameters!\n' >&2
-    printf 'Call "%s -h" for a help page.\n' "$called" >&2
+    printf 'Call "%s -?" for a help page.\n' "$called" >&2
     exit 1
   ;;
 esac
 
 if [ -z "$patchlist" ] || printf %s "$patchlist" | grep -q '[$&();<>|]'; then
   printf 'Patchlist is empty or contains illegal characters!\n' >&2
-  printf 'Call "%s -h" for a help page.\n' "$called" >&2
+  printf 'Call "%s -?" for a help page.\n' "$called" >&2
   exit 1
 fi
 


### PR DESCRIPTION
… because this is more common (especially the pair `-?` and `--help` as synonyms) and it frees `-h` for something else (often "human readable", though currently I cannot see how this might be applicable here).