### PR TITLE
[patchmanager.cpp] Fix-up release 3.2.10 ⇒ 3.2.11

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -23,7 +23,7 @@
 Name:       patchmanager
 
 Summary:    Allows to manage Patches for SailfishOS
-Version:    3.2.10
+Version:    3.2.11
 Release:    1
 # The Group tag should comprise one of the groups listed here:
 # https://github.com/mer-tools/spectacle/blob/master/data/GROUPS

--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -1025,7 +1025,7 @@ void PatchManager::activation(const QString &patch, const QString &version)
     \warning probably dead code, need to investigate
     probably \internal, using \a easterText
 */
-void PatchManager::easterReceived(const QString &easterText);
+void PatchManager::easterReceived(const QString &easterText)
 {
 }
 

--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -1013,22 +1013,6 @@ bool PatchManagerTranslator::installTranslator(const QString &patch)
     return true;
 }
 
-/*! void PatchManager::activation(const QString &patch, const QString &version);
-    \warning probably dead code, need to investigate
-    probably \internal, using \a patch and \a version
-*/
-void PatchManager::activation(const QString &patch, const QString &version)
-{
-}
-
-/*!  void PatchManager::easterReceived(const QString &easterText);
-    \warning probably dead code, need to investigate
-    probably \internal, using \a easterText
-*/
-void PatchManager::easterReceived(const QString &easterText)
-{
-}
-
 /*!
     Returns \e true if \a filename exists, \e false otherwise.
     \sa https://doc.qt.io/qt-5/qfile.html#exists-1

--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -1013,19 +1013,19 @@ bool PatchManagerTranslator::installTranslator(const QString &patch)
     return true;
 }
 
-/*! void PatchManager::activation(const QString & patch, const QString & version);
+/*! void PatchManager::activation(const QString &patch, const QString &version);
     \warning probably dead code, need to investigate
     probably \internal, using \a patch and \a version
 */
-void PatchManager::activation(const QString & patch, const QString & version)
+void PatchManager::activation(const QString &patch, const QString &version)
 {
 }
 
-/*!  void PatchManager::easterReceived(const QString & easterText);
+/*!  void PatchManager::easterReceived(const QString &easterText);
     \warning probably dead code, need to investigate
     probably \internal, using \a easterText
 */
-void PatchManager::easterReceived(const QString & easterText);
+void PatchManager::easterReceived(const QString &easterText);
 {
 }
 

--- a/src/qml/patchmanager.h
+++ b/src/qml/patchmanager.h
@@ -157,7 +157,7 @@ public slots:
 
     bool installTranslator(const QString & patch);
     bool removeTranslator(const QString & patch);
-    void activation(const QString & patch, const QString & version);    // Apparently unused!
+    void activation(const QString & patch, const QString & version);
     int checkVote(const QString &patch) const;
     void doVote(const QString &patch, int action);
     void checkEaster();
@@ -185,7 +185,7 @@ public slots:
     void resolveFailure();
 
 signals:
-    void easterReceived(const QString & easterText);    // Apparently unused!
+    void easterReceived(const QString & easterText);
     void developerModeChanged(bool developerMode);
     void patchDevelModeChanged(bool patchDevelMode);
     void sfosVersionCheckChanged(bool sfosVersionCheck);

--- a/src/qml/patchmanager.h
+++ b/src/qml/patchmanager.h
@@ -66,7 +66,7 @@ public:
     enum CheckMode {
         Strict,
         NoCheck,
-        //Relaxed,    // TODO, Issue #322, also see https://github.com/sailfishos-patches/patchmanager/issues/333#issuecomment-1374118045
+        //Relaxed,    // TODO, see issue #322, also see https://github.com/sailfishos-patches/patchmanager/issues/333#issuecomment-1374118045
     };
     Q_ENUM(CheckMode)
 private:
@@ -157,7 +157,7 @@ public slots:
 
     bool installTranslator(const QString & patch);
     bool removeTranslator(const QString & patch);
-    void activation(const QString & patch, const QString & version);
+    void activation(const QString & patch, const QString & version);    // Apparently unused!
     int checkVote(const QString &patch) const;
     void doVote(const QString &patch, int action);
     void checkEaster();
@@ -185,7 +185,7 @@ public slots:
     void resolveFailure();
 
 signals:
-    void easterReceived(const QString & easterText);
+    void easterReceived(const QString & easterText);    // Apparently unused!
     void developerModeChanged(bool developerMode);
     void patchDevelModeChanged(bool patchDevelMode);
     void sfosVersionCheckChanged(bool sfosVersionCheck);


### PR DESCRIPTION
This was introduced by https://github.com/sailfishos-patches/patchmanager/commit/e30292be22fc6644e8b5ba32ac9612395bb11aff#diff-df38830cae3d3051528c63a2740fe3b0b4ec2c6b59aadab35dce5a1b6e995dd4R1016-R1035.  I still do not understand the purpose of this addition, specifically in the light of the comment(s) stating *"probably dead code, need to investigate"*: It sure is dead code, as these two newly added classes here do not contain any code at all.  Likely this is a combination of my lack of understanding and these comments lacking information needed for me to understand the purpose of this addition.

Another point to investigate: Why did [earlier CI runs not show this compile failure](https://github.com/sailfishos-patches/patchmanager/actions)?