### PR TITLE
[patchmanager.cpp] Reintroduce two dummy methods for documentation …

### DIFF
--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -1031,7 +1031,7 @@ void PatchManager::activation(const QString & patch, const QString & version)
     /* 
         Requires dummy operations, utilising patch and version; otherwise
         a [-Werror=unused-parameter] is emitted, turned into an error
-        by the global CONFIG_WERROR=y switch.
+        by the global CONFIG_WERROR=y switch, which breaks the CI runs.
     */
 }
 
@@ -1046,7 +1046,7 @@ void PatchManager::easterReceived(const QString & easterText)
     /* 
         Requires a dummy operation, utilising easterText; otherwise
         a [-Werror=unused-parameter] is emitted, turned into an error
-        by the global CONFIG_WERROR=y switch.
+        by the global CONFIG_WERROR=y switch, which breaks the CI runs.
     */
 }
 

--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -1013,6 +1013,43 @@ bool PatchManagerTranslator::installTranslator(const QString &patch)
     return true;
 }
 
+/*
+The only purpose of the following two empty methods is to document 
+their corresponding definitions in /src/qml/patchmanager.h, 
+because qdoc warns about undocumented classes and functions, but 
+does not allow for qdoc source documentation in header files.  
+*/
+    
+/*! void PatchManager::activation(const QString & patch, const QString & version);
+    Defined in line 160 (section "public slots:") of /src/qml/patchmanager.h
+    Used in line 295 of /src/qml/AboutPage.qml
+    \warning probably dead code, need to investigate
+    probably \internal, using \a patch and \a version
+*/
+void PatchManager::activation(const QString & patch, const QString & version)
+{
+    /* 
+        Requires dummy operations, utilising patch and version;
+        otherwise an "unused variable"-warning is emitted, which
+        is turned into an error by "treat warnings as errors".
+    */
+}
+
+/*! void PatchManager::easterReceived(const QString & easterText);
+    Defined in line 188 (section "signals:") of /src/qml/patchmanager.h
+    Used in line 2514 of /src/bin/patchmanager-daemon/patchmanagerobject.cpp
+    \warning probably dead code, need to investigate
+    probably \internal, using \a easterText
+*/
+void PatchManager::easterReceived(const QString & easterText)
+{
+    /* 
+        Requires a dummy operation, utilising easterText;
+        otherwise an "unused variable"-warning is emitted, which
+        is turned into an error by "treat warnings as errors".
+    */
+}
+
 /*!
     Returns \e true if \a filename exists, \e false otherwise.
     \sa https://doc.qt.io/qt-5/qfile.html#exists-1

--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -1014,10 +1014,10 @@ bool PatchManagerTranslator::installTranslator(const QString &patch)
 }
 
 /*
-The only purpose of the following two empty methods is to document 
-their corresponding definitions in /src/qml/patchmanager.h, 
-because qdoc warns about undocumented classes and functions, but 
-does not allow for qdoc source documentation in header files.  
+    The only purpose of the following two dummy methods is to document
+    their corresponding definitions in /src/qml/patchmanager.h,
+    because qdoc warns about undocumented classes and functions, but
+    does not allow for qdoc source documentation in header files.
 */
     
 /*! void PatchManager::activation(const QString & patch, const QString & version);

--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -1029,9 +1029,9 @@ does not allow for qdoc source documentation in header files.
 void PatchManager::activation(const QString & patch, const QString & version)
 {
     /* 
-        Requires dummy operations, utilising patch and version;
-        otherwise an "unused variable"-warning is emitted, which
-        is turned into an error by "treat warnings as errors".
+        Requires dummy operations, utilising patch and version; otherwise
+        a [-Werror=unused-parameter] is emitted, turned into an error
+        by the global CONFIG_WERROR=y switch.
     */
 }
 
@@ -1044,9 +1044,9 @@ void PatchManager::activation(const QString & patch, const QString & version)
 void PatchManager::easterReceived(const QString & easterText)
 {
     /* 
-        Requires a dummy operation, utilising easterText;
-        otherwise an "unused variable"-warning is emitted, which
-        is turned into an error by "treat warnings as errors".
+        Requires a dummy operation, utilising easterText; otherwise
+        a [-Werror=unused-parameter] is emitted, turned into an error
+        by the global CONFIG_WERROR=y switch.
     */
 }
 


### PR DESCRIPTION
… purposes only in order to silence `qdoc` warnings WRT undocumented classes, methods and functions.
Reference: The core aspect of the whole back and forth in PR #451: https://github.com/sailfishos-patches/patchmanager/pull/451