### PR TITLE
Slightly overhaul CI workflows

### DIFF
--- a/.github/workflows/ci-on-pull_req.yml
+++ b/.github/workflows/ci-on-pull_req.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  # Do not wait up to the default of 10 minutes for network timeouts in a workflow which runs at most 3 minutes
+  # Do not wait up to the default of 10 minutes for network timeouts in a workflow which runs ca. 5 minutes
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
 
 defaults:
@@ -18,9 +18,10 @@ defaults:
     # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
     shell: sh
 
+# See, e.g.: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
 concurrency:
-  group: ${{ github.ref_name }}
-  cancel-in-progress: true
+  group: ci-${{ github.ref_name }}
+  cancel-in-progress: false  # 'false' (default) allows for two concurrent runs, one executing and one freshly enqueued; 'true' for only one; no 'concurrency:' defined for multiple.
 
 jobs:
   build:
@@ -79,6 +80,6 @@ jobs:
 
 # Just for fun, see https://feathericons.com/ and
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding
-#branding:  # "Invalid workflow file: Unexpected value 'branding'"; maybe the name MUST be action.yml, see e.g., https://github.com/actions/cache/blob/main/action.yml#L37
+#branding:  # "Invalid workflow file: Unexpected value 'branding'"; maybe action MUST be located in '/' or the name MUST be action.yml, see e.g., https://github.com/actions/cache/blob/main/action.yml#L37
 #  icon: 'gift'
 #  color: 'purple'

--- a/.github/workflows/ci-on-pull_req.yml
+++ b/.github/workflows/ci-on-pull_req.yml
@@ -1,17 +1,35 @@
-name: CI on Pull Request to master and patchmanager3 branches
+name: CI on PRs to master & patchmanager3 branches
 
 on:
   pull_request:
     branches:
       - master
       - patchmanager3
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  # Do not wait up to the default of 10 minutes for network timeouts in a workflow which runs at most 3 minutes
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+
+defaults:
+  run:
+    # Note thas 'bash' provides -o pipefail, in contrast to the default (i.e., unspecified, which also uses bash) or 'sh',
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: sh
+
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-22.04
     env:
-      SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
+      ARCH: i486
+      RELEASE: 3.4.0.24
     steps:
+
     - name: Checkout
       uses: actions/checkout@v3
 
@@ -28,9 +46,6 @@ jobs:
     #    key: cache
 
     - name: Build ${{ env.ARCH }} on ${{ env.RELEASE }}
-      env:
-        ARCH: i486
-        RELEASE: 3.4.0.24
       run: |
         set -x
         mkdir -p output/$RELEASE/$ARCH
@@ -44,7 +59,7 @@ jobs:
     - name: Upload build results
       uses: actions/upload-artifact@v3
       with:
-        name: RPM-build-results
+        name: RPM-build-results-${{ env.RELEASE }}-${{ env.ARCH }}
         path: output/
 
 # "Create release" does not fit here, because this workflow is triggered by Pull Requests,
@@ -61,3 +76,10 @@ jobs:
 #        hub release create"$assets" -m "$tag_name" "$tag_name"
 #      env:
 #        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# Just for fun, see https://feathericons.com/ and
+# https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding
+branding:
+  icon: 'gift'
+  color: 'purple'
+

--- a/.github/workflows/ci-on-pull_req.yml
+++ b/.github/workflows/ci-on-pull_req.yml
@@ -79,7 +79,6 @@ jobs:
 
 # Just for fun, see https://feathericons.com/ and
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding
-branding:
-  icon: 'gift'
-  color: 'purple'
-
+#branding:  # "Invalid workflow file: Unexpected value 'branding'"; maybe the name MUST be action.yml, see e.g., https://github.com/actions/cache/blob/main/action.yml#L37
+#  icon: 'gift'
+#  color: 'purple'

--- a/.github/workflows/ci-on-tags.yml
+++ b/.github/workflows/ci-on-tags.yml
@@ -171,3 +171,4 @@ jobs:
 branding:
   icon: 'gift'
   color: 'purple'
+

--- a/.github/workflows/ci-on-tags.yml
+++ b/.github/workflows/ci-on-tags.yml
@@ -168,7 +168,6 @@ jobs:
 
 # Just for fun, see https://feathericons.com/ and
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding
-branding:
-  icon: 'gift'
-  color: 'purple'
-
+# branding:  # It does not like it, may be the name MUST be action.yml, see e.g., https://github.com/actions/cache/blob/main/action.yml#L37
+#  icon: 'gift'
+#  color: 'purple'

--- a/.github/workflows/ci-on-tags.yml
+++ b/.github/workflows/ci-on-tags.yml
@@ -3,18 +3,39 @@ name: CI on tags
 on:
   push:
     tags:
-      - '*'
+      # '**' also matches the slash ('/'), in contrast to '*', see 
+      - '**'
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 env:
+  # For the latest available docker image, see https://github.com/CODeRUS/docker-sailfishos-platform-sdk
   LATEST: 4.5.0.16
+  # Do not wait up to the default of 10 minutes for a workflow which runs at most 15 minutes
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+
+defaults:
+  run:
+    # Note thas 'bash' provides -o pipefail, in contrast to the default (i.e., unspecified, which also uses bash) or 'sh',
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: sh
+
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-22.04
+  # One job for the latest Docker images used and one for the oldest ones.
+  # Trying to download three multi-GB, layered docker images in a single job may
+  # result in "docker: write /var/lib/docker/tmp/GetImageBlobXYZ: no space left on device."
+  
+  build-on-LATEST:
     env:
-      SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+      RELEASE: ${{ env.LATEST }}
+    runs-on: ubuntu-22.04
     steps:
-    - name: Checkout
+
+    - name: Checkout git repository
       uses: actions/checkout@v3
 
     #- name: Prepare
@@ -31,8 +52,7 @@ jobs:
 
     - name: Build ${{ env.ARCH }} on ${{ env.RELEASE }}
       env:
-        ARCH: aarch64
-        RELEASE: ${{ env.LATEST }}
+        ARCH: i486
       run: |
         set -x
         mkdir -p output/$RELEASE/$ARCH
@@ -46,7 +66,6 @@ jobs:
     - name: Build ${{ env.ARCH }} on ${{ env.RELEASE }}
       env:
         ARCH: armv7hl
-        RELEASE: ${{ env.LATEST }}
       run: |
         set -x
         mkdir -p output/$RELEASE/$ARCH
@@ -59,8 +78,48 @@ jobs:
 
     - name: Build ${{ env.ARCH }} on ${{ env.RELEASE }}
       env:
+        ARCH: aarch64
+      run: |
+        set -x
+        mkdir -p output/$RELEASE/$ARCH
+        docker run --rm -v $PWD:/share coderus/sailfishos-platform-sdk:$RELEASE /bin/sh -xc '
+           mkdir -p build
+           cd build
+           cp -r /share/. .
+           mb2 -t SailfishOS-$1-$2 build -d
+           sudo cp -r RPMS/. /share/output/$1/$2/' sh_mb2 $RELEASE $ARCH
+
+    - name: Upload build results
+      uses: actions/upload-artifact@v3
+      with:
+        name: RPM-build-results-${{ env.RELEASE }}
+        path: output/
+
+  build-on-OLDEST:
+    runs-on: ubuntu-22.04
+    steps:
+
+    - name: Checkout git repository
+      uses: actions/checkout@v3
+
+    - name: Build ${{ env.ARCH }} on ${{ env.RELEASE }}
+      env:
         ARCH: i486
-        RELEASE: ${{ env.LATEST }}
+        RELEASE: 3.4.0.24
+      run: |
+        set -x
+        mkdir -p output/$RELEASE/$ARCH
+        docker run --rm -v $PWD:/share coderus/sailfishos-platform-sdk:$RELEASE /bin/sh -xc '
+           mkdir -p build
+           cd build
+           cp -r /share/. .
+           mb2 -t SailfishOS-$1-$2 build -d
+           sudo cp -r RPMS/. /share/output/$1/$2/' sh_mb2 $RELEASE $ARCH
+
+    - name: Build ${{ env.ARCH }} on ${{ env.RELEASE }}
+      env:
+        ARCH: armv7hl
+        RELEASE: 3.4.0.24
       run: |
         set -x
         mkdir -p output/$RELEASE/$ARCH
@@ -85,38 +144,10 @@ jobs:
            mb2 -t SailfishOS-$1-$2 build -d
            sudo cp -r RPMS/. /share/output/$1/$2/' sh_mb2 $RELEASE $ARCH
 
-    - name: Build ${{ env.ARCH }} on ${{ env.RELEASE }}
-      env:
-        ARCH: armv7hl
-        RELEASE: 3.4.0.24
-      run: |
-        set -x
-        mkdir -p output/$RELEASE/$ARCH
-        docker run --rm -v $PWD:/share coderus/sailfishos-platform-sdk:$RELEASE /bin/sh -xc '
-           mkdir -p build
-           cd build
-           cp -r /share/. .
-           mb2 -t SailfishOS-$1-$2 build -d
-           sudo cp -r RPMS/. /share/output/$1/$2/' sh_mb2 $RELEASE $ARCH
-
-    - name: Build ${{ env.ARCH }} on ${{ env.RELEASE }}
-      env:
-        ARCH: i486
-        RELEASE: 3.4.0.24
-      run: |
-        set -x
-        mkdir -p output/$RELEASE/$ARCH
-        docker run --rm -v $PWD:/share coderus/sailfishos-platform-sdk:$RELEASE /bin/sh -xc '
-           mkdir -p build
-           cd build
-           cp -r /share/. .
-           mb2 -t SailfishOS-$1-$2 build -d
-           sudo cp -r RPMS/. /share/output/$1/$2/' sh_mb2 $RELEASE $ARCH
-
     - name: Upload build results
       uses: actions/upload-artifact@v3
       with:
-        name: RPM-build-results
+        name: RPM-build-results-OLDEST
         path: output/
 
 # Due to building two releases for each architecture, they will clobber each other,
@@ -133,3 +164,9 @@ jobs:
 #        hub release create"$assets" -m "$tag_name" "$tag_name"
 #      env:
 #        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# Just for fun, see https://feathericons.com/ and
+# https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding
+branding:
+  icon: 'gift'
+  color: 'purple'

--- a/.github/workflows/ci-on-tags.yml
+++ b/.github/workflows/ci-on-tags.yml
@@ -168,6 +168,6 @@ jobs:
 
 # Just for fun, see https://feathericons.com/ and
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding
-# branding:  # It does not like it, may be the name MUST be action.yml, see e.g., https://github.com/actions/cache/blob/main/action.yml#L37
+#branding:  # "Invalid workflow file: Unexpected value 'branding'"; maybe the name MUST be action.yml, see e.g., https://github.com/actions/cache/blob/main/action.yml#L37
 #  icon: 'gift'
 #  color: 'purple'

--- a/.github/workflows/ci-on-tags.yml
+++ b/.github/workflows/ci-on-tags.yml
@@ -9,10 +9,11 @@ on:
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# See, e.g.: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
 env:
   # For the latest available docker image, see https://github.com/CODeRUS/docker-sailfishos-platform-sdk
   LATEST: 4.5.0.16
-  # Do not wait up to the default of 10 minutes for network timeouts in a workflow which runs at most 15 minutes
+  # Do not wait up to the default of 10 minutes for network timeouts in a workflow which runs at most 20 minutes
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
 defaults:
@@ -22,8 +23,8 @@ defaults:
     shell: sh
 
 concurrency:
-  group: ${{ github.ref_name }}
-  cancel-in-progress: true
+  group: ci-${{ github.ref_name }}
+  cancel-in-progress: false  # 'false' (default) allows for two concurrent runs, one executing and one freshly enqueued; 'true' for only one; no 'concurrency:' defined for multiple.
 
 jobs:
   # One job for the latest Docker images used and one for the oldest ones.
@@ -168,6 +169,6 @@ jobs:
 
 # Just for fun, see https://feathericons.com/ and
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding
-#branding:  # "Invalid workflow file: Unexpected value 'branding'"; maybe the name MUST be action.yml, see e.g., https://github.com/actions/cache/blob/main/action.yml#L37
+#branding:  # "Invalid workflow file: Unexpected value 'branding'"; maybe action MUST be located in '/' or the name MUST be action.yml, see e.g., https://github.com/actions/cache/blob/main/action.yml#L37
 #  icon: 'gift'
 #  color: 'purple'

--- a/.github/workflows/ci-on-tags.yml
+++ b/.github/workflows/ci-on-tags.yml
@@ -3,7 +3,8 @@ name: CI on tags
 on:
   push:
     tags:
-      # '**' also matches the slash ('/'), in contrast to '*', see 
+      # '**' also matches the slash ('/'), in contrast to '*',
+      # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
       - '**'
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -11,7 +12,7 @@ on:
 env:
   # For the latest available docker image, see https://github.com/CODeRUS/docker-sailfishos-platform-sdk
   LATEST: 4.5.0.16
-  # Do not wait up to the default of 10 minutes for a workflow which runs at most 15 minutes
+  # Do not wait up to the default of 10 minutes for network timeouts in a workflow which runs at most 15 minutes
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
 defaults:


### PR DESCRIPTION
Trigger / Rationale: Trying to download three multi-GB, layered docker images in a single job may result in `docker: write /var/lib/docker/tmp/GetImageBlobXYZ: no space left on device.`, see https://github.com/sailfishos-patches/patchmanager/actions/runs/5871696093/job/15921691170#step:7:45
Hence splitting the "big" `CI on tags` workflow into two jobs and slightly enhancing both CI workflows.