### PR TITLE
[QML] Align WebPatch Details design with Patch Details

### DIFF
--- a/src/qml/UnifiedPatchPage.qml
+++ b/src/qml/UnifiedPatchPage.qml
@@ -265,8 +265,6 @@ Page {
                                 }
                                 Label {
                                     anchors.verticalCenter: parent.verticalCenter
-                                    color: Theme.secondaryHighlightColor
-                                    linkColor: Theme.highlightColor
                                     text: linktext
                                 }
                             }

--- a/src/qml/WebPatchPage.qml
+++ b/src/qml/WebPatchPage.qml
@@ -332,8 +332,6 @@ Page {
                                 }
                                 Label {
                                     anchors.verticalCenter: parent.verticalCenter
-                                    color: Theme.secondaryHighlightColor
-                                    linkColor: Theme.highlightColor
                                     text: linktext
                                 }
                             }


### PR DESCRIPTION
This makes the details for a patch from the catalog appear similar to that of an installed patch
