### PR TITLE
[Doc] Remove/Improve build-breaking "Dummy" method docs

### DIFF
--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -614,7 +614,10 @@ void PatchManager::doVote(const QString &patch, int action)
     putSettingsSync(QStringLiteral("votes/%1").arg(patch), action);
 }
 
-/*! \internal lets not spoil the fun (or the eggs!). */
+/*!
+   \internal
+   lets not spoil the fun (or the eggs!).
+*/
 void PatchManager::checkEaster()
 {
     qDebug() << Q_FUNC_INFO;
@@ -1023,14 +1026,18 @@ bool PatchManagerTranslator::installTranslator(const QString &patch)
 /*! \fn void PatchManager::activation(const QString & patch, const QString & version);
     \internal
     using \a patch and \a version
-    \warning dead code, need to investigate removal
+    \warning This seems to be dead code as nothing seems to attach to this slot, need to investigate removal
 */
 
 /*! \fn void PatchManager::easterReceived(const QString &easterText);
     \internal
-    This signal is emitted when checkEaster() has determined there is an easter egg to display.
-    using \a easterText
-    \warning probably dead code, need to investigate removal
+
+    This signal is emitted when checkEaster() has determined there is an easter
+    egg to display, and contains \a easterText as a string parameter.
+
+    Used in AboutPage to display an easter egg.
+
+    \sa AboutPage
 */
 
 /*!

--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -1019,36 +1019,19 @@ bool PatchManagerTranslator::installTranslator(const QString &patch)
     because qdoc warns about undocumented classes and functions, but
     does not allow for qdoc source documentation in header files.
 */
-    
-/*! void PatchManager::activation(const QString & patch, const QString & version);
-    Defined in line 160 (section "public slots:") of /src/qml/patchmanager.h
-    Used in line 295 of /src/qml/AboutPage.qml
-    \warning probably dead code, need to investigate
-    probably \internal, using \a patch and \a version
-*/
-void PatchManager::activation(const QString & patch, const QString & version)
-{
-    /* 
-        Requires dummy operations, utilising patch and version; otherwise
-        a [-Werror=unused-parameter] is emitted, turned into an error
-        by the global CONFIG_WERROR=y switch, which breaks the CI runs.
-    */
-}
 
-/*! void PatchManager::easterReceived(const QString & easterText);
-    Defined in line 188 (section "signals:") of /src/qml/patchmanager.h
-    Used in line 2514 of /src/bin/patchmanager-daemon/patchmanagerobject.cpp
-    \warning probably dead code, need to investigate
-    probably \internal, using \a easterText
+/*! \fn void PatchManager::activation(const QString & patch, const QString & version);
+    \internal
+    using \a patch and \a version
+    \warning dead code, need to investigate removal
 */
-void PatchManager::easterReceived(const QString & easterText)
-{
-    /* 
-        Requires a dummy operation, utilising easterText; otherwise
-        a [-Werror=unused-parameter] is emitted, turned into an error
-        by the global CONFIG_WERROR=y switch, which breaks the CI runs.
-    */
-}
+
+/*! \fn void PatchManager::easterReceived(const QString &easterText);
+    \internal
+    This signal is emitted when checkEaster() has determined there is an easter egg to display.
+    using \a easterText
+    \warning probably dead code, need to investigate removal
+*/
 
 /*!
     Returns \e true if \a filename exists, \e false otherwise.


### PR DESCRIPTION
Turns out these methods are not so dummy after all. (See #452)

One is a Signal, which shouldn't have an implementation at all.

The other is indeed dead code, but lack of usage o its parameter broke the
build. Instad of wrapping it in `Q_UNUSED`, lets just not have an
implementation, just the qdoc comment.

This now does silence qdoc, and does not break the build.

