### PR TITLE
[patchmanagerobject.cpp] Omit stale full stop in notification …

### DIFF
--- a/src/bin/patchmanager-daemon/patchmanagerobject.cpp
+++ b/src/bin/patchmanager-daemon/patchmanagerobject.cpp
@@ -275,7 +275,7 @@ void PatchManagerObject::notify(const QString &patch, NotifyAction action)
     switch (action) {
     case NotifyActionSuccessApply:
         summary = qApp->translate("", "Patch activated");
-        body = qApp->translate("", "Patch %1 activated.").arg(patch);
+        body = qApp->translate("", "Patch %1 activated").arg(patch);
         if (getToggleServices()) {
             body.append( ", " );
             body.append( qApp->translate("", "some service(s) should be restarted.") );

--- a/translations/settings-patchmanager-de.ts
+++ b/translations/settings-patchmanager-de.ts
@@ -457,8 +457,8 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="235"/>
-        <source>Patch %1 activated.</source>
-        <translation>Patch %1 wurde aktiviert.</translation>
+        <source>Patch %1 activated</source>
+        <translation>Patch %1 wurde aktiviert</translation>
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="238"/>

--- a/translations/settings-patchmanager-es.ts
+++ b/translations/settings-patchmanager-es.ts
@@ -457,8 +457,8 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="235"/>
-        <source>Patch %1 activated.</source>
-        <translation>Parche %1 activado.</translation>
+        <source>Patch %1 activated</source>
+        <translation>Parche %1 activado</translation>
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="238"/>

--- a/translations/settings-patchmanager-ru.ts
+++ b/translations/settings-patchmanager-ru.ts
@@ -442,8 +442,8 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="235"/>
-        <source>Patch %1 activated.</source>
-        <translation>Применён патч %1.</translation>
+        <source>Patch %1 activated</source>
+        <translation>Применён патч %1</translation>
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="238"/>

--- a/translations/settings-patchmanager-sk.ts
+++ b/translations/settings-patchmanager-sk.ts
@@ -457,8 +457,8 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="235"/>
-        <source>Patch %1 activated.</source>
-        <translation>Oprava %1 bola aktivovaná.</translation>
+        <source>Patch %1 activated</source>
+        <translation>Oprava %1 bola aktivovaná</translation>
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="238"/>

--- a/translations/settings-patchmanager-sl.ts
+++ b/translations/settings-patchmanager-sl.ts
@@ -442,7 +442,7 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="235"/>
-        <source>Patch %1 activated.</source>
+        <source>Patch %1 activated</source>
         <translation>Popravek %1 je aktiviran</translation>
     </message>
     <message>

--- a/translations/settings-patchmanager-sv.ts
+++ b/translations/settings-patchmanager-sv.ts
@@ -457,8 +457,8 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="235"/>
-        <source>Patch %1 activated.</source>
-        <translation>Korrigering %1 aktiverad.</translation>
+        <source>Patch %1 activated</source>
+        <translation>Korrigering %1 aktiverad</translation>
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="238"/>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -459,7 +459,7 @@
     </message>
     <message>
         <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="235"/>
-        <source>Patch %1 activated.</source>
+        <source>Patch %1 activated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
… text, because the (original) initial message `Patch %1 activated.` (line 278) is either extended by `, ` (line 280) and `some service(s) should be restarted.` (line 281), or concluded with `.` (line 284).
Fixes #466