### PR TITLE
Package icons as subpackages

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -59,6 +59,7 @@ BuildRequires:  pkgconfig(popt)
 Summary:    Icon files for %{name}
 BuildArch:  noarch
 Requires:   sailfish-version >= 4.6.0
+Requires:   %{name} >= %{version}
 Provides:   %{name}-icons
 Conflicts:  %{name}-icons-meegotouch
 Obsoletes:  %{name}-icons-meegotouch
@@ -67,6 +68,7 @@ Obsoletes:  %{name}-icons-meegotouch
 Summary:    Icon files for %{name}
 BuildArch:  noarch
 Requires:   sailfish-version < 4.6.0
+Requires:   %{name} >= %{version}
 Provides:   %{name}-icons
 Conflicts:  %{name}-icons-silica
 


### PR DESCRIPTION
Supporting two different filesystem locations depending on Sailfish OS version
while keeping the number of build environments to a minimum is problematic.

Instead of deciding where to install and what to package at build time, package and ship
both variants and let the package manager decide which is the right one.

See also: https://github.com/sailfishos-patches/patchmanager/pull/472#issuecomment-2499936641

- **Package icons as subpackages**
- **Copy generated icons around**
- **Add Obsoletes, in order to provide an upgrade path**

Things to test:

 - [x] picks the correct package on SFOS 4.6 and/or 5.0
 - [ ] picks the correct package on SFOS 4.5 and lower
 - [ ] picks the correct package when updating from an installed Patchmanager version to the one including this change 
 - [ ] Shows icon correctly after installation (for all of the above)
 - [ ] Removes icons at the `meegotouch` path and installs them at the `silica` location after/during an update from a lower version to SFOS 4.6
   SFOS GUI upgrades usually remove Patchmanager anyway AFAIK, so this last test may not be that important.