### PR TITLE
[.github/workflows/*] Update GH-actions' and Linux versions

### DIFF
--- a/.github/workflows/ci-on-pull_req.yml
+++ b/.github/workflows/ci-on-pull_req.yml
@@ -27,7 +27,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       # Solely builds for i486 on 3.4.0, because of https://github.com/sailfishos-patches/patchmanager/pull/437#issuecomment-1615317003
       ARCH: i486
@@ -35,7 +35,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     #- name: Prepare
     #  run:
@@ -61,7 +61,7 @@ jobs:
            sudo cp -r RPMS/. /share/output/$1/$2/' sh_mb2 $RELEASE $ARCH
 
     - name: Upload build results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: RPM-build-results_${{ env.RELEASE }}-${{ env.ARCH }}
         path: output/

--- a/.github/workflows/ci-on-tags.yml
+++ b/.github/workflows/ci-on-tags.yml
@@ -37,11 +37,11 @@ jobs:
   build-on-LATEST:
     env:
       RELEASE: ${{ env.LATEST }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
     - name: Checkout git repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     #- name: Prepare
     #  run: 
@@ -95,17 +95,17 @@ jobs:
            sudo cp -r RPMS/. /share/output/$1/$2/' sh_mb2 $RELEASE $ARCH
 
     - name: Upload build results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: RPM-build-results_SDK-for-${{ env.RELEASE }}
         path: output/
 
   build-on-OLDEST:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
     - name: Checkout git repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build ${{ env.ARCH }} on ${{ env.RELEASE }}
       env:
@@ -150,7 +150,7 @@ jobs:
            sudo cp -r RPMS/. /share/output/$1/$2/' sh_mb2 $RELEASE $ARCH
 
     - name: Upload build results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: RPM-build-results_SDK-for-OLDEST
         path: output/

--- a/.github/workflows/gendoc-create-html_qt56.yml
+++ b/.github/workflows/gendoc-create-html_qt56.yml
@@ -24,12 +24,12 @@ jobs:
   #     - Use a docker image containing `qdoc` to generate the files
   #     - upload the results so the deployment job can pick it up
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
     steps:
     - name: Checkout Source (${{ inputs.DOC_SOURCE_BRANCH }})
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.DOC_SOURCE_BRANCH }}
     - name: Generate Docs
@@ -72,14 +72,14 @@ jobs:
       run: echo "$REDIRECTOR" > out/index.html
     # Upload artifact for deploying to pages:
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: './out'
 
   # Now deploy to GH Pages
   deploy:
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Grant GITHUB_TOKEN the permissions required by deploy-pages action
     permissions:
       pages: write      # to deploy to Pages
@@ -89,5 +89,5 @@ jobs:
       uses: actions/configure-pages@v3
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4
 

--- a/.github/workflows/gendoc-create-html_qt56.yml
+++ b/.github/workflows/gendoc-create-html_qt56.yml
@@ -86,7 +86,7 @@ jobs:
       id-token: write   # to verify the deployment originates from an appropriate source
     steps:
     - name: Setup Pages
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v5
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4


### PR DESCRIPTION
* **`ci-on-tags.yml`** & **`ci-on-pull_req.yml`**
  - [`ubuntu-22.04` **→** `ubuntu-24.04`](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
  - [`actions/checkout@v3`**→**`@v4`](https://github.com/actions/checkout#readme)
  - [`actions/upload-artifact@v3`**→**`@v4`](https://github.com/actions/upload-artifact#readme)
* **`gendoc-create-html_qt56.yml`**
  - [`ubuntu-22.04` **→** `ubuntu-24.04`](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
  - [`actions/checkout@v3`**→**`@v4`](https://github.com/actions/checkout#readme)
  - [`actions/upload-pages-artifact@v1`**→**`@v3`](https://github.com/actions/upload-pages-artifact#readme)
  - [`actions/configure-pages@v3`**→**`@v5`](https://github.com/actions/configure-pages#readme)
  - [`actions/deploy-pages@v2`**→**`@v4`](https://github.com/actions/deploy-pages#readme)