### PR TITLE
Minor adjustments to a couple of text strings

### DIFF
--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -169,7 +169,7 @@ Page {
                     font.pixelSize: Theme.fontSizeSmall
                     wrapMode: Text.WordWrap
                     horizontalAlignment: Text.AlignJustify
-                    text: qsTranslate("", "If you appreciate our work, please consider a donation to help covering the hosting costs for Openrepos. Openrepos is critical infrastructure specifically for Patchmanager, because its Web Catalog of Patches is hosted there.")
+                    text: qsTranslate("", "If you appreciate our work, please consider a donation to help covering the hosting costs for OpenRepos. OpenRepos is critical infrastructure specifically for Patchmanager, because its Web Catalog of Patches is hosted there.")
                 }
                 Text {
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -190,7 +190,7 @@ Page {
                     font.pixelSize: Theme.fontSizeSmall
                     wrapMode: Text.WordWrap
                     horizontalAlignment: Text.AlignJustify
-                    text: qsTranslate("", "If for some reason you cannot donate to Openrepos, we also appreciate donating to the Free Software Foundation Europe (FSFE).")
+                    text: qsTranslate("", "If for some reason you cannot donate to OpenRepos, we also appreciate donating to the Free Software Foundation Europe (FSFE).")
                 }
 
                 Text {

--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -115,7 +115,7 @@ Page {
                 }
                 Text {
                         anchors.horizontalCenter: parent.horizontalCenter
-                        text: qsTranslate("", "Sources and Issue Tracker<br /><a href=\"%1\">on GitHub</a>").arg(SOURCE_REPO)
+                        text: qsTranslate("", "Source code and Issue Tracker<br /><a href=\"%1\">on GitHub</a>").arg(SOURCE_REPO)
                         textFormat: Text.StyledText
                         horizontalAlignment: Text.AlignHCenter
                         font.pixelSize: Theme.fontSizeSmall

--- a/src/qml/AboutPage.qml
+++ b/src/qml/AboutPage.qml
@@ -115,7 +115,7 @@ Page {
                 }
                 Text {
                         anchors.horizontalCenter: parent.horizontalCenter
-                        text: qsTranslate("", "Source code and Issue Tracker<br /><a href=\"%1\">on GitHub</a>").arg(SOURCE_REPO)
+                        text: qsTranslate("", "Source code repository and issue<br />tracker for bug reports, feature<br />suggestions and help requests<br /><a href=\"%1\">on GitHub</a>").arg(SOURCE_REPO)
                         textFormat: Text.StyledText
                         horizontalAlignment: Text.AlignHCenter
                         font.pixelSize: Theme.fontSizeSmall

--- a/src/qml/PatchManagerPage.qml
+++ b/src/qml/PatchManagerPage.qml
@@ -647,7 +647,7 @@ Page {
                     }
                     MenuItem {
                         id: patchinfoitem
-                        text: qsTranslate("", "Patch details")
+                        text: qsTranslate("", "Details")
                         onClicked: background.openPatchInfo()
                     }
                     MenuItem {

--- a/src/qml/UnifiedPatchPage.qml
+++ b/src/qml/UnifiedPatchPage.qml
@@ -227,7 +227,7 @@ Page {
                     if (modelData.sources) {
                       linksmodel.append({
                           "link": modelData.sources,
-                          "linktext": qsTranslate("", "Sources"),
+                          "linktext": qsTranslate("", "Source code"),
                           "iconname": "icon-s-developer"
                       })
                     }

--- a/src/qml/UnifiedPatchPage.qml
+++ b/src/qml/UnifiedPatchPage.qml
@@ -162,7 +162,7 @@ Page {
             }
             SectionHeader {
                 visible: modelData.conflicts.length > 0
-                text: qsTranslate("", "May conflict with the following Patches:")
+                text: qsTranslate("", "May conflict with these Patches:")
             }
             Repeater {
                 visible: modelData.conflicts.length > 0

--- a/src/qml/UnifiedPatchPage.qml
+++ b/src/qml/UnifiedPatchPage.qml
@@ -227,7 +227,7 @@ Page {
                     if (modelData.sources) {
                       linksmodel.append({
                           "link": modelData.sources,
-                          "linktext": qsTranslate("", "Source code"),
+                          "linktext": qsTranslate("", "Source code repository"),
                           "iconname": "icon-s-developer"
                       })
                     }

--- a/src/qml/UnifiedPatchPage.qml
+++ b/src/qml/UnifiedPatchPage.qml
@@ -162,7 +162,7 @@ Page {
             }
             SectionHeader {
                 visible: modelData.conflicts.length > 0
-                text: qsTranslate("", "May conflict with:")
+                text: qsTranslate("", "May conflict with the following Patches:")
             }
             Repeater {
                 visible: modelData.conflicts.length > 0

--- a/src/qml/WebPatchPage.qml
+++ b/src/qml/WebPatchPage.qml
@@ -123,7 +123,7 @@ Page {
             if (patchData.sources) {
                 linksmodel.append({
                     "link": patchData.sources,
-                    "linktext": qsTranslate("", "Sources"),
+                    "linktext": qsTranslate("", "Source code"),
                     "iconname": "icon-s-developer"
                 })
             }

--- a/src/qml/WebPatchPage.qml
+++ b/src/qml/WebPatchPage.qml
@@ -124,7 +124,7 @@ Page {
             if (patchData.sources) {
                 linksmodel.append({
                     "link": patchData.sources,
-                    "linktext": qsTranslate("", "Source code"),
+                    "linktext": qsTranslate("", "Source code repository"),
                     "iconname": "icon-m-developer-mode"
                 })
             }

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -275,7 +275,7 @@
     <message>
         <location filename="../src/qml/PatchManagerPage.qml" line="515"/>
         <location filename="../src/qml/WebPatchPage.qml" line="99"/>
-        <source>Patch details</source>
+        <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="en">
 <context>
     <name></name>
     <message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -81,12 +81,12 @@
     </message>
     <message>
         <location filename="../src/qml/AboutPage.qml" line="165"/>
-        <source>If you appreciate our work, please consider a donation to help covering the hosting costs for Openrepos. Openrepos is critical infrastructure specifically for Patchmanager, because its Web Catalog of Patches is hosted there.</source>
+        <source>If you appreciate our work, please consider a donation to help covering the hosting costs for OpenRepos. OpenRepos is critical infrastructure specifically for Patchmanager, because its Web Catalog of Patches is hosted there.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/qml/AboutPage.qml" line="186"/>
-        <source>If for some reason you cannot donate to Openrepos, we also appreciate donating to the Free Software Foundation Europe (FSFE).</source>
+        <source>If for some reason you cannot donate to OpenRepos, we also appreciate donating to the Free Software Foundation Europe (FSFE).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -4,593 +4,640 @@
 <context>
     <name></name>
     <message>
-        <location filename="../src/bin/dialog/dialog.qml" line="63"/>
-        <location filename="../src/bin/dialog/dialog.qml" line="80"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="66"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="89"/>
         <source>Activate all enabled Patches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/dialog/dialog.qml" line="89"/>
-        <source>Patchmanager will start to activate all enabled Patches in 10 seconds.</source>
+        <location filename="../src/bin/dialog/dialog.qml" line="98"/>
+        <source>Patchmanager will start to activate all enabled Patches in %1 seconds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/dialog/dialog.qml" line="102"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="111"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/dialog/dialog.qml" line="177"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="186"/>
         <source>Activating all enabled Patches took %L1 seconds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/dialog/dialog.qml" line="179"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="188"/>
         <source>Successfully activated all enabled Patches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/dialog/dialog.qml" line="180"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="189"/>
         <source>Failed to activate all enabled Patches!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="54"/>
-        <location filename="../src/qml/PatchManagerPage.qml" line="168"/>
+        <location filename="../src/qml/AboutPage.qml" line="61"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="215"/>
         <source>About Patchmanager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="283"/>
-        <location filename="../src/bin/dialog/dialog.qml" line="208"/>
-        <location filename="../src/qml/AboutPage.qml" line="68"/>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="79"/>
+        <location filename="../src/bin/dialog/dialog.qml" line="217"/>
+        <location filename="../src/qml/AboutPage.qml" line="75"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="116"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="326"/>
         <source>Patchmanager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="76"/>
+        <location filename="../src/qml/AboutPage.qml" line="83"/>
         <source>Version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="87"/>
+        <location filename="../src/qml/AboutPage.qml" line="94"/>
         <source>Patchmanager allows to automatically modify system files via Patches. It provides a daemon which performs the activation of Patches, plus a GUI to configure these operations and to install or remove Patches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="101"/>
+        <location filename="../src/qml/AboutPage.qml" line="108"/>
         <source>Licensed under the terms of the&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;BSD 3-Clause License&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="111"/>
-        <source>Source code and Issue Tracker&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;on GitHub&lt;/a&gt;</source>
+        <location filename="../src/qml/AboutPage.qml" line="118"/>
+        <source>Source code repository and issue&lt;br /&gt;tracker for bug reports, feature&lt;br /&gt;suggestions and help requests&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;on GitHub&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="128"/>
+        <location filename="../src/qml/AboutPage.qml" line="135"/>
         <source>Credits and Acknowledgements&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;Developers&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="153"/>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="215"/>
+        <location filename="../src/qml/AboutPage.qml" line="160"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="237"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="134"/>
         <source>Donations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="165"/>
+        <location filename="../src/qml/AboutPage.qml" line="172"/>
         <source>If you appreciate our work, please consider a donation to help covering the hosting costs for OpenRepos. OpenRepos is critical infrastructure specifically for Patchmanager, because its Web Catalog of Patches is hosted there.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/AboutPage.qml" line="186"/>
+        <location filename="../src/qml/AboutPage.qml" line="193"/>
         <source>If for some reason you cannot donate to OpenRepos, we also appreciate donating to the Free Software Foundation Europe (FSFE).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="260"/>
-        <source>Donate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/DevelopersPage.qml" line="152"/>
+        <location filename="../src/qml/DevelopersPage.qml" line="159"/>
         <source>Developers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/DevelopersPage.qml" line="191"/>
+        <location filename="../src/qml/DevelopersPage.qml" line="198"/>
         <source>%1&apos;s webpage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/DevelopersPage.qml" line="196"/>
+        <location filename="../src/qml/DevelopersPage.qml" line="203"/>
         <source>%1&apos;s %2 account</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="53"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="76"/>
         <source>Copied log to clipboard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="70"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="93"/>
         <source>Activating Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="72"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="95"/>
         <source>Deactivate Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="73"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="96"/>
         <source>Activate Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="80"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="103"/>
         <source>Remove Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="83"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="106"/>
         <source>Patch %1 removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="90"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="113"/>
         <source>Start Patchmanager&apos;s daemon before activating Patches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="112"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="135"/>
         <source>This Patch is not available anymore. You will not be able to reinstall it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="121"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="144"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="121"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="144"/>
         <source>Maintainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="125"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="148"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="126"/>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="131"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="149"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="154"/>
         <source>not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="130"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="153"/>
         <source>Compatible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="142"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="165"/>
         <source>May conflict with the following Patches:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="170"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="193"/>
         <source>This Patch uses the legacy format for its patch.json file. If you are its maintainer, please do consider updating to the new format; if you are using the Web Catalog you shall not include a patch.json file in your upload!&lt;br /&gt;See the developer section in the &lt;a href=&quot;%1&quot;&gt;README&lt;/a&gt; for details.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="176"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="199"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="292"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="201"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="223"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="120"/>
         <source>Discussion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="258"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="230"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="127"/>
+        <source>Source code repository</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="278"/>
         <source>Patch log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="267"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="287"/>
         <source>Press and hold to copy log to the clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="280"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="300"/>
         <source>No log exists yet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="162"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="209"/>
         <source>Disable and deactivate all Patches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="178"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="225"/>
         <source>Start Patchmanager&apos;s daemon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="184"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="231"/>
         <source>Updates available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="184"/>
-        <location filename="../src/qml/WebCatalogPage.qml" line="106"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="231"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="157"/>
         <source>Web Catalog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="190"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="237"/>
         <source>Restart preloaded services</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="196"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="243"/>
+        <source>Restore prior enabled list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/PatchManagerPage.qml" line="249"/>
         <source>Resolve failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="203"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="256"/>
         <source>Installed Patches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="382"/>
-        <location filename="../src/qml/WebPatchPage.qml" line="348"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="414"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="412"/>
         <source>This Patch is incompatible with the installed SailfishOS version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="390"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="422"/>
         <source>Removing Patch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="495"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="616"/>
+        <source>Tap to configure</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/PatchManagerPage.qml" line="617"/>
+        <source>Tap to show configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/PatchManagerPage.qml" line="630"/>
         <source>Compatible with:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="510"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="645"/>
         <source>May conflict with another Patch, see %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="511"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="646"/>
         <source>May conflict with %2 other Patches, see %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="515"/>
-        <location filename="../src/qml/WebPatchPage.qml" line="99"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="650"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="519"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="654"/>
         <source>Deactivate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="519"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="654"/>
         <source>Activate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="524"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="659"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="538"/>
-        <location filename="../src/qml/WebCatalogPage.qml" line="249"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="674"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="314"/>
         <source>No Patches available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="53"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="66"/>
         <source>Restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="59"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="72"/>
         <source>Some services will be restarted now. Reloading the homescreen of the device might take a little time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="63"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="76"/>
         <source>List of services:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="78"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="115"/>
         <source>Note that this will close all apps.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="79"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="116"/>
         <source>Note that this will close %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/RestartServicesDialog.qml" line="82"/>
+        <location filename="../src/qml/RestartServicesDialog.qml" line="119"/>
         <source>Note that this will close the %1 app.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/ScreenshotsPage.qml" line="71"/>
-        <location filename="../src/qml/WebPatchPage.qml" line="286"/>
+        <location filename="../src/qml/ScreenshotsPage.qml" line="90"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="346"/>
         <source>Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="88"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="139"/>
         <source>Hide search field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="88"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="139"/>
         <source>Show search field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="94"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="145"/>
         <source>Sort by category</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="94"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="145"/>
         <source>Sort by date updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="106"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="157"/>
         <source>%1 Patches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="107"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="158"/>
         <source>(by date updated)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="107"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="158"/>
         <source>(by category)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="113"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="164"/>
         <source>Tap to enter search query</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebCatalogPage.qml" line="236"/>
+        <location filename="../src/qml/WebCatalogPage.qml" line="301"/>
         <source>Update available: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="80"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="165"/>
         <source>Failed to fetch Patch data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="80"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="165"/>
         <source>Fetching patch data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="86"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="171"/>
         <source>Open Project Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="202"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="287"/>
         <source>Author: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="190"/>
-        <location filename="../src/qml/WebPatchPage.qml" line="218"/>
+        <location filename="../src/qml/UnifiedPatchPage.qml" line="212"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="307"/>
         <source>Links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="239"/>
-        <source>Open discussion link</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/UnifiedPatchPage.qml" line="208"/>
-        <location filename="../src/qml/WebPatchPage.qml" line="281"/>
-        <source>Source code</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="332"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="392"/>
         <source>Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="350"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="414"/>
         <source>Install Patch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="352"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="410"/>
         <source>Re-Install Patch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="407"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="184"/>
+        <source>Patch details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/WebPatchPage.qml" line="469"/>
         <source>[tap to re-install]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="408"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="470"/>
         <source>[installed]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="410"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="472"/>
         <source>[tap to install]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/WebPatchPage.qml" line="426"/>
+        <location filename="../src/qml/WebPatchPage.qml" line="488"/>
         <source>Compatible: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="234"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="277"/>
         <source>Patch activated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="235"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="278"/>
         <source>Patch %1 activated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="238"/>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="249"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="281"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="292"/>
         <source>some service(s) should be restarted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="245"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="288"/>
         <source>Patch deactivated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="246"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="289"/>
         <source>Patch %1 is now inactive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="256"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="299"/>
         <source>Failed to activate Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="257"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="300"/>
         <source>Activating Patch %1 failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="260"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="303"/>
         <source>Failed to deactivate Patch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="261"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="304"/>
         <source>Deactivating Patch %1 failed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="264"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="307"/>
         <source>Update available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="265"/>
+        <location filename="../src/bin/patchmanager-daemon/patchmanagerobject.cpp" line="308"/>
         <source>An update for Patch %1 is available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/PatchManagerPage.qml" line="173"/>
-        <location filename="../src/qml/SettingsPage.qml" line="79"/>
+        <location filename="../src/qml/PatchManagerPage.qml" line="220"/>
+        <location filename="../src/qml/SettingsPage.qml" line="91"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="82"/>
+        <location filename="../src/qml/SettingsPage.qml" line="94"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="85"/>
+        <location filename="../src/qml/SettingsPage.qml" line="97"/>
         <source>Show notification on success</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="86"/>
+        <location filename="../src/qml/SettingsPage.qml" line="98"/>
         <source>If this is off, notifications will only be shown when something went wrong.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="93"/>
-        <source>Activate enabled Patches when booting</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/SettingsPage.qml" line="101"/>
+        <location filename="../src/qml/SettingsPage.qml" line="105"/>
         <source>Show &apos;Disable and deactivate all Patches&apos; pulley menu entry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="102"/>
+        <location filename="../src/qml/SettingsPage.qml" line="106"/>
         <source>Enable an additional pulley menu entry for Patchmanager&apos;s main page to disable and deactivate all Patches.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="116"/>
-        <source>Version Check</source>
+        <location filename="../src/qml/SettingsPage.qml" line="113"/>
+        <source>Show only updates in Web Catalog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="122"/>
-        <source>Strict</source>
+        <location filename="../src/qml/SettingsPage.qml" line="114"/>
+        <source>When updates are available, hide all other Patches in Web Catalog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/SettingsPage.qml" line="120"/>
+        <source>Startup Activation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/qml/SettingsPage.qml" line="123"/>
-        <source>No check</source>
+        <source>Activate Patches on first login</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="129"/>
-        <source>Mode for Patch developers</source>
+        <location filename="../src/qml/SettingsPage.qml" line="124"/>
+        <source>Automatically activate all enabled Patches after Home Screen has been started for the first time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="130"/>
-        <source>Enable various functions to be used by Patch developers. Among other things, it shows debug log files for applying the patch file when a Patch is activated on its details page.</source>
+        <location filename="../src/qml/SettingsPage.qml" line="139"/>
+        <source>Activation Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/SettingsPage.qml" line="108"/>
-        <source>Advanced</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/SettingsPage.qml" line="94"/>
-        <source>Automatically activate all enabled Patches when SailfishOS starts.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/qml/SettingsPage.qml" line="117"/>
-        <source>Allow to enable Patches, which are not marked as compatible with the installed SailfishOS version. Note that Patches, which are actually incompatible, will not work.</source>
+        <location filename="../src/qml/SettingsPage.qml" line="140"/>
+        <source>%1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/qml/SettingsPage.qml" line="149"/>
-        <source>Convert Patches between 32-bit and 64-bit</source>
+        <source>Activate Patches when booting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/SettingsPage.qml" line="164"/>
+        <source>Version Check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/SettingsPage.qml" line="170"/>
+        <source>Strict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/SettingsPage.qml" line="171"/>
+        <source>No check</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/SettingsPage.qml" line="177"/>
+        <source>Mode for Patch developers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/SettingsPage.qml" line="178"/>
+        <source>Enable various functions to be used by Patch developers. Among other things, it shows debug log files for applying the patch file when a Patch is activated on its details page.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/SettingsPage.qml" line="156"/>
+        <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/qml/SettingsPage.qml" line="150"/>
+        <source>Automatically activate all enabled Patches when SailfishOS starts.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/SettingsPage.qml" line="165"/>
+        <source>Allow to enable Patches, which are not marked as compatible with the installed SailfishOS version. Note that Patches, which are actually incompatible, will not work.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/SettingsPage.qml" line="197"/>
+        <source>Convert Patches between 32-bit and 64-bit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/SettingsPage.qml" line="198"/>
         <source>Automatically convert lib or lib64 for select paths shown below.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -664,7 +711,7 @@
     </message>
     <message>
         <location filename="../src/qml/patchmanager.cpp" line="68"/>
-        <location filename="../src/qml/patchmanager.cpp" line="283"/>
+        <location filename="../src/qml/patchmanager.cpp" line="327"/>
         <source>other</source>
         <translation>Other</translation>
     </message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -177,7 +177,7 @@
     </message>
     <message>
         <location filename="../src/qml/UnifiedPatchPage.qml" line="142"/>
-        <source>May conflict with:</source>
+        <source>May conflict with the following Patches:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -65,7 +65,7 @@
     </message>
     <message>
         <location filename="../src/qml/AboutPage.qml" line="111"/>
-        <source>Sources and Issue Tracker&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;on GitHub&lt;/a&gt;</source>
+        <source>Source code and Issue Tracker&lt;br /&gt;&lt;a href=&quot;%1&quot;&gt;on GitHub&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -414,7 +414,7 @@
     <message>
         <location filename="../src/qml/UnifiedPatchPage.qml" line="208"/>
         <location filename="../src/qml/WebPatchPage.qml" line="281"/>
-        <source>Sources</source>
+        <source>Source code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/settings-patchmanager.ts
+++ b/translations/settings-patchmanager.ts
@@ -173,7 +173,7 @@
     </message>
     <message>
         <location filename="../src/qml/UnifiedPatchPage.qml" line="165"/>
-        <source>May conflict with the following Patches:</source>
+        <source>May conflict with these Patches:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
I have made changes according to the earlier discussion, see it here: https://github.com/sailfishos-patches/patchmanager/discussions/157#discussioncomment-12111731

Summarum:

1. "Patch details" -> "Details"
2. "Openrepos" -> "OpenRepos"
3. "Sources" -> "Source code"
4. "May conflict with:" -> "May conflict with the following Patches:"