### PR TITLE
[ci-on-tags.yml] Fix new sematic error in old code

### DIFF
--- a/.github/workflows/ci-on-tags.yml
+++ b/.github/workflows/ci-on-tags.yml
@@ -11,10 +11,6 @@ on:
   # Rather set a new tag in the format N/X.Y.Z (e.g., 1/0.6.3) to build a release originally tagged with 0.6.3 again.
 
 env:
-  # For the available docker images, see https://github.com/CODeRUS/docker-sailfishos-platform-sdk
-  # But LATEST means here, "known to run on the latest SailfishOS release": Binaries for 4.3.0 are known to run on 5.0.0,
-  # though altered icon paths by 4.6.0 require building for it, for details see https://github.com/sailfishos-patches/patchmanager/pull/479#pullrequestreview-2483451820
-  LATEST: 4.6.0.13
   # Do not wait up to the default of 10 minutes for network timeouts in a workflow which runs at most 20 minutes.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
@@ -36,8 +32,11 @@ jobs:
   # results in "docker: write /var/lib/docker/tmp/GetImageBlobXYZ: no space left on device."
 
   build-on-LATEST:
+  # For the available docker images, see https://github.com/CODeRUS/docker-sailfishos-platform-sdk
+  # But LATEST means here, "known to run on the latest SailfishOS release": Binaries for 4.3.0 are known to run on 5.0.0,
+  # though altered icon paths by 4.6.0 require building for it, for details see https://github.com/sailfishos-patches/patchmanager/pull/479#pullrequestreview-2483451820
     env:
-      RELEASE: ${{ env.LATEST }}
+      RELEASE: 4.6.0.13
     runs-on: ubuntu-24.04
     steps:
 


### PR DESCRIPTION
This construct was working fine for years in GH actions YML files, but ceased to some time between mid-Februray and mid-March 2025.
```
jobs:
  <job name>:
    env:
      RELEASE: ${{ env.LATEST }}
```
And "Yes, the variable [`env.LATEST` was correctly set](https://github.com/sailfishos-patches/patchmanager/pull/496/files#diff-67b09c17f87da4adcefdd2a8cad10e771ed3b562773c7134e46d53be4ac1f5faL13-L17)"!

The [resulting error message](https://github.com/user-attachments/assets/0159786c-1d7d-4f5e-9af8-57fb58498151) is:
>  Check failure on line 40 in .github/workflows/ci-on-tags.yml
GitHub Actions / CI on tags
> Invalid workflow file
> The workflow is not valid. .github/workflows/ci-on-tags.yml (Line: 40, Col: 16): Unrecognized named-value: 'env'. Located at position 1 within expression: env.LATEST