### PR TITLE
preload: use C linker instead of c++

### DIFF
--- a/src/preload/preload.pro
+++ b/src/preload/preload.pro
@@ -2,6 +2,7 @@ TEMPLATE = lib
 QT =
 CONFIG += plugin
 CONFIG += link_pkgconfig
+CONFIG += use_c_linker
 PKGCONFIG += libshadowutils
 INCLUDEPATH += /usr/include/libshadowutils
 QMAKE_CFLAGS += -std=c11 -Werror


### PR DESCRIPTION
Minor, but allows compilation without having a full-blown c++ compiler installed.

This makes on-device testing a little bit easer for the author.
