### PR TITLE
Move preload and firejail setup to oneshot script

### DIFF
--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -182,7 +182,12 @@ exit 0
 
 %post
 export NO_PM_PRELOAD=1
-%{_bindir}/add-oneshot patchmanager-setup-preload.sh
+
+# set up the oneshot script, and run it immediately
+# If --now is given, job is run immediately instead of postponing it later
+# If instant run fails the link is created for later run
+%{_bindir}/add-oneshot --now patchmanager-setup-preload.sh
+
 case "$1" in
 1)  # Installation
   echo "Installing %{name}: %%post section"

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -39,6 +39,7 @@ Requires:   grep
 Requires:   sed
 Requires:   sailfish-version >= 3.4.0
 Requires:   qml(Nemo.Configuration)
+Requires:   oneshot
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Qml)
@@ -53,6 +54,7 @@ BuildRequires:  pkgconfig(libshadowutils)
 BuildRequires:  qt5-qttools-linguist
 BuildRequires:  pkgconfig(rpm)
 BuildRequires:  pkgconfig(popt)
+BuildRequires:  oneshot
 
 
 %package testcases
@@ -180,6 +182,7 @@ exit 0
 
 %post
 export NO_PM_PRELOAD=1
+%{_bindir}/add-oneshot patchmanager-setup-preload.sh
 case "$1" in
 1)  # Installation
   echo "Installing %{name}: %%post section"
@@ -198,13 +201,6 @@ case "$1" in
   echo "Case $1 is not handled in %%post section of %{name}!"
 ;;
 esac
-sed -i '/libpreload%{name}/ d' /etc/ld.so.preload
-echo '%{_libdir}/libpreload%{name}.so' >> /etc/ld.so.preload
-/sbin/ldconfig
-if ! grep -qsF 'include whitelist-common-%{name}.local' /etc/firejail/whitelist-common.local
-then
-  echo 'include whitelist-common-%{name}.local' >> /etc/firejail/whitelist-common.local
-fi
 dbus-send --system --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
 systemctl daemon-reload
 systemctl-user daemon-reload
@@ -289,6 +285,8 @@ exit 0
 
 %attr(0755,root,root) %{_libexecdir}/pm_apply
 %attr(0755,root,root) %{_libexecdir}/pm_unapply
+
+%attr(0755,root,root) %{_oneshotdir}/patchmanager-setup-preload.sh
 
 %{_libdir}/qt5/qml/org/SfietKonstantin/%{name}
 %{_datadir}/%{name}/data

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -39,7 +39,6 @@ Requires:   grep
 Requires:   sed
 Requires:   sailfish-version >= 3.4.0
 Requires:   qml(Nemo.Configuration)
-Requires:   oneshot
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Qml)
@@ -54,8 +53,10 @@ BuildRequires:  pkgconfig(libshadowutils)
 BuildRequires:  qt5-qttools-linguist
 BuildRequires:  pkgconfig(rpm)
 BuildRequires:  pkgconfig(popt)
-BuildRequires:  oneshot
 
+%_oneshot_requires_post
+BuildRequires:  oneshot
+Requires:   oneshot
 
 %package testcases
 Summary:    Provides test cases for Patchmanager
@@ -183,14 +184,15 @@ exit 0
 %post
 export NO_PM_PRELOAD=1
 
-# set up the oneshot script, and run it immediately
-# If --now is given, job is run immediately instead of postponing it later
-# If instant run fails the link is created for later run
-%{_bindir}/add-oneshot --now patchmanager-setup-preload.sh
-
 case "$1" in
 1)  # Installation
   echo "Installing %{name}: %%post section"
+
+  # set up the oneshot script, and run it immediately
+  # If --now is given, job is run immediately instead of postponing it later
+  # If instant run fails the link is created for later run
+  %{_bindir}/add-oneshot --now patchmanager-setup-preload.sh
+
   # See #507: https://github.com/sailfishos-patches/patchmanager/issues/507
   if [ $(getent group inet) ]
   then echo "O.K., this system has an 'inet' group."

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -188,9 +188,9 @@ case "$1" in
 1)  # Installation
   echo "Installing %{name}: %%post section"
 
-  # set up the oneshot script, and run it immediately
-  # If --now is given, job is run immediately instead of postponing it later
-  # If instant run fails the link is created for later run
+  # Set up an oneshot script, and run it immediately.
+  # If --now is given, the job is run immediately instead of postponing it.
+  # If running instantly fails the oneshot script's link is created for a later run.
   %{_bindir}/add-oneshot --now patchmanager-setup-preload.sh
 
   # See #507: https://github.com/sailfishos-patches/patchmanager/issues/507

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -149,6 +149,9 @@ ln -s ../checkForUpdates-org.SfietKonstantin.patchmanager.timer %{buildroot}%{_u
 mkdir -p %{buildroot}/%{_userunitdir}/lipstick.service.wants/
 ln -s ../lipstick-patchmanager.service %{buildroot}/%{_userunitdir}/lipstick.service.wants/
 
+mkdir -p %{buildroot}/%{_unitdir}/system-update.target.wants/
+ln -s ../patchmanager-sailfish-upgrade-watcher.service %{buildroot}%{_unitdir}/system-update.target.wants/
+
 mkdir -p %{buildroot}%{_datadir}/%{name}/patches
 
 
@@ -283,6 +286,7 @@ exit 0
 %{_unitdir}/checkForUpdates-org.SfietKonstantin.patchmanager.timer
 %{_unitdir}/timers.target.wants/checkForUpdates-org.SfietKonstantin.patchmanager.timer
 %{_unitdir}/patchmanager-sailfish-upgrade-watcher.service
+%{_unitdir}/system-update.target.wants/patchmanager-sailfish-upgrade-watcher.service
 %{_sharedstatedir}/environment/patchmanager/10-dbus.conf
 %{_sharedstatedir}/environment/patchmanager/90-debug.conf
 %{_userunitdir}/dbus-org.SfietKonstantin.patchmanager.service

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -282,6 +282,7 @@ exit 0
 %{_unitdir}/checkForUpdates-org.SfietKonstantin.patchmanager.service
 %{_unitdir}/checkForUpdates-org.SfietKonstantin.patchmanager.timer
 %{_unitdir}/timers.target.wants/checkForUpdates-org.SfietKonstantin.patchmanager.timer
+%{_unitdir}/patchmanager-sailfish-upgrade-watcher.service
 %{_sharedstatedir}/environment/patchmanager/10-dbus.conf
 %{_sharedstatedir}/environment/patchmanager/90-debug.conf
 %{_userunitdir}/dbus-org.SfietKonstantin.patchmanager.service

--- a/rpm/patchmanager.spec
+++ b/rpm/patchmanager.spec
@@ -188,11 +188,6 @@ case "$1" in
 1)  # Installation
   echo "Installing %{name}: %%post section"
 
-  # Set up an oneshot script, and run it immediately.
-  # If --now is given, the job is run immediately instead of postponing it.
-  # If running instantly fails the oneshot script's link is created for a later run.
-  %{_bindir}/add-oneshot --now patchmanager-setup-preload.sh
-
   # See #507: https://github.com/sailfishos-patches/patchmanager/issues/507
   if [ $(getent group inet) ]
   then echo "O.K., this system has an 'inet' group."
@@ -208,6 +203,12 @@ case "$1" in
   echo "Case $1 is not handled in %%post section of %{name}!"
 ;;
 esac
+
+# Set up an oneshot script, and run it immediately.
+# If --now is given, the job is run immediately instead of postponing it.
+# If running instantly fails the oneshot script's link is created for a later run.
+%{_bindir}/add-oneshot --now patchmanager-setup-preload.sh
+
 dbus-send --system --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
 systemctl daemon-reload
 systemctl-user daemon-reload

--- a/src/oneshot/oneshot.pro
+++ b/src/oneshot/oneshot.pro
@@ -1,0 +1,9 @@
+TEMPLATE = aux
+
+# oneshot.d is Sailish OS specific. See https://github.com/sailfishos/oneshot
+# While the path could be configurable though the %{_oneshotdir} RPM macro,
+# this location seems stable enough.
+oneshot.path = /usr/lib/oneshot.d/
+oneshot.files = patchmanager-setup-preload.sh
+
+INSTALLS += oneshot

--- a/src/oneshot/oneshot.pro
+++ b/src/oneshot/oneshot.pro
@@ -7,3 +7,9 @@ oneshot.path = /usr/lib/oneshot.d/
 oneshot.files = patchmanager-setup-preload.sh
 
 INSTALLS += oneshot
+
+# Systemd
+oneshot-systemd.files = src/oneshot/patchmanager-sailfish-upgrade-watcher.service
+oneshot-systemd.path = /usr/lib/systemd/system/
+INSTALLS += oneshot-systemd
+

--- a/src/oneshot/oneshot.pro
+++ b/src/oneshot/oneshot.pro
@@ -1,8 +1,8 @@
 TEMPLATE = aux
 
-# oneshot.d is Sailish OS specific. See https://github.com/sailfishos/oneshot
-# While the path could be configurable though the %{_oneshotdir} RPM macro,
-# this location seems stable enough.
+# oneshot.d is SailishOS specific, see https://github.com/sailfishos/oneshot
+# While its path is configurable via the %{_oneshotdir} RPM macro,
+# this location seems stable.
 oneshot.path = /usr/lib/oneshot.d/
 oneshot.files = patchmanager-setup-preload.sh
 

--- a/src/oneshot/oneshot.pro
+++ b/src/oneshot/oneshot.pro
@@ -9,7 +9,7 @@ oneshot.files = patchmanager-setup-preload.sh
 INSTALLS += oneshot
 
 # Systemd
-oneshot-systemd.files = src/oneshot/patchmanager-sailfish-upgrade-watcher.service
+oneshot-systemd.files = patchmanager-sailfish-upgrade-watcher.service
 oneshot-systemd.path = /usr/lib/systemd/system/
 INSTALLS += oneshot-systemd
 

--- a/src/oneshot/patchmanager-sailfish-upgrade-watcher.service
+++ b/src/oneshot/patchmanager-sailfish-upgrade-watcher.service
@@ -21,7 +21,3 @@ RemainAfterExit=True
 
 ExecStart=/bin/true
 ExecStop=/usr/bin/add-oneshot patchmanager-setup-preload.sh
-
-# Recommendation would be to ship the symlink manually
-[Install]
-WantedBy=system-update.target

--- a/src/oneshot/patchmanager-sailfish-upgrade-watcher.service
+++ b/src/oneshot/patchmanager-sailfish-upgrade-watcher.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Patchmanager OS upgrade watcher.
+
+Before=system-update.target
+After=system-update-pre.target
+After=sailfish-upgrade-ui.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=True
+
+ExecStart=/bin/true
+ExecStop=/usr/bin/add-oneshot patchmanager-setup-preload.sh
+
+# Recommendation would be to ship the symlink manually
+[Install]
+WantedBy=system-update.target

--- a/src/oneshot/patchmanager-sailfish-upgrade-watcher.service
+++ b/src/oneshot/patchmanager-sailfish-upgrade-watcher.service
@@ -1,9 +1,14 @@
 [Unit]
 Description=Patchmanager OS upgrade watcher.
 
+DefaultDependencies=no
 Before=system-update.target
 After=system-update-pre.target
 After=sailfish-upgrade-ui.service
+
+# Make sure we're "executed" on reboot/shutdown:
+Conflicts=shutdown.target
+Before=shutdown.target
 
 [Service]
 Type=oneshot

--- a/src/oneshot/patchmanager-sailfish-upgrade-watcher.service
+++ b/src/oneshot/patchmanager-sailfish-upgrade-watcher.service
@@ -1,3 +1,8 @@
+# This Unit is supposed to *only* get activated in OS update mode, and then
+# started just before shutdown.
+#
+# Hence we Conflict with shutdown, and are WantedBy system-update.target.
+
 [Unit]
 Description=Patchmanager OS upgrade watcher.
 

--- a/src/oneshot/patchmanager-setup-preload.sh
+++ b/src/oneshot/patchmanager-setup-preload.sh
@@ -9,7 +9,7 @@ if [ x"${qual}" = x"64" ]; then
   libdir=/usr/lib64
 fi
 
-if ! grep -qsF '/libpreloadpatchmanager/' /etc/ld.so.preload
+if ! grep -qsF 'libpreloadpatchmanager.so' /etc/ld.so.preload
 then
 echo "${libdir}/libpreloadpatchmanager.so" >> /etc/ld.so.preload
 fi

--- a/src/oneshot/patchmanager-setup-preload.sh
+++ b/src/oneshot/patchmanager-setup-preload.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# don't interfer with ourselves
+export NO_PM_PRELOAD=1
+
+qual=$(getconf LONG_BIT)
+libdir=/usr/lib
+if [ x"${qual}" = x"64" ]; then
+  libdir=/usr/lib64
+fi
+
+if ! grep -qsF '/libpreloadpatchmanager/' /etc/ld.so.preload
+then
+echo "${libdir}/libpreloadpatchmanager.so" >> /etc/ld.so.preload
+fi
+
+/sbin/ldconfig
+if ! grep -qsF 'include whitelist-common-patchmanager.local' /etc/firejail/whitelist-common.local
+then
+  echo 'include whitelist-common-patchmanager.local' >> /etc/firejail/whitelist-common.local
+fi
+

--- a/src/oneshot/patchmanager-setup-preload.sh
+++ b/src/oneshot/patchmanager-setup-preload.sh
@@ -17,12 +17,24 @@ fi
 
 if ! grep -qsF 'libpreloadpatchmanager.so' /etc/ld.so.preload
 then
-echo "${libdir}/libpreloadpatchmanager.so" >> /etc/ld.so.preload
+  echo "${libdir}/libpreloadpatchmanager.so" >> /etc/ld.so.preload
+  if [ $? -ne 0 ]; then
+    echo "patchmanager-setup-preload - setting up preload FAILed. Trying again next boot"
+    exit 1
+  fi
 fi
 
 /sbin/ldconfig
+
 if ! grep -qsF 'include whitelist-common-patchmanager.local' /etc/firejail/whitelist-common.local
 then
   echo 'include whitelist-common-patchmanager.local' >> /etc/firejail/whitelist-common.local
+  if [ $? -ne 0 ]; then
+    echo "patchmanager-setup-preload - setting up whitelist FAILed. Trying again next boot"
+    exit 1
+  fi
 fi
 
+echo "patchmanager-setup-preload - system setup SUCCESSFUL."
+
+exit 0

--- a/src/oneshot/patchmanager-setup-preload.sh
+++ b/src/oneshot/patchmanager-setup-preload.sh
@@ -9,6 +9,14 @@ if [ "$MIC_RUN" != "" ]; then
   exit 1
 fi
 
+# While updating, return failure so we get run at next boot
+# See https://github.com/sailfishos-patches/patchmanager/issues/39#issuecomment-940607912
+if [ -e /tmp/os-update-running ]
+then
+  echo "patchmanager-setup-preload - returning FAIL to postpone oneshot to next boot"
+  exit 1
+fi
+
 qual=$(getconf LONG_BIT)
 libdir=/usr/lib
 if [ x"${qual}" = x"64" ]; then

--- a/src/oneshot/patchmanager-setup-preload.sh
+++ b/src/oneshot/patchmanager-setup-preload.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# don't interfer with ourselves
+# Do not interfere with ourselves
 export NO_PM_PRELOAD=1
 
 qual=$(getconf LONG_BIT)

--- a/src/oneshot/patchmanager-setup-preload.sh
+++ b/src/oneshot/patchmanager-setup-preload.sh
@@ -3,6 +3,12 @@
 # Do not interfere with ourselves
 export NO_PM_PRELOAD=1
 
+set +e
+if [ "$MIC_RUN" != "" ]; then
+  echo "patchmanager-setup-preload - returning FAIL to postpone oneshot to first boot"
+  exit 1
+fi
+
 qual=$(getconf LONG_BIT)
 libdir=/usr/lib
 if [ x"${qual}" = x"64" ]; then

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,2 +1,2 @@
 TEMPLATE = subdirs
-SUBDIRS = bin etc qml share plugin icons preload tools
+SUBDIRS = bin etc qml share plugin icons preload tools oneshot


### PR DESCRIPTION
Workarounds/fixes for #521

Instead of setting up files in `%post`, do it in a script and launch that
through the oneshot feature

