### PR TITLE
Daemon: do not start during OS update

### DIFF
--- a/src/bin/patchmanager-daemon/systemd/dbus-org.SfietKonstantin.patchmanager.service
+++ b/src/bin/patchmanager-daemon/systemd/dbus-org.SfietKonstantin.patchmanager.service
@@ -3,6 +3,7 @@ Description=Patchmanager service
 Requires=dbus.service
 After=dbus.service
 Before=systemd-user-sessions.service
+ConditionPathExists=!/tmp/os-update-running
 
 [Service]
 Type=dbus


### PR DESCRIPTION
A bit hard to test.

The ConditionPathExists also appears this way in the lipstick service,
therefore I conclude it's the preferred way of handling this.
