### PR TITLE
Bitness mangling: default to true

### DIFF
--- a/src/qml/patchmanager.cpp
+++ b/src/qml/patchmanager.cpp
@@ -303,7 +303,7 @@ void PatchManager::setNotifyOnSuccess(bool notifyOnSuccess)
 */
 bool PatchManager::bitnessMangle() const
 {
-    return getSettingsSync(QStringLiteral("bitnessMangle"), false).toBool();
+    return getSettingsSync(QStringLiteral("bitnessMangle"), true).toBool();
 }
 
 void PatchManager::setBitnessMangle(bool bitnessMangle)


### PR DESCRIPTION
This was set to false when mangling was a new feature.
It's been around for a while now and seems to work well.

Switch it on per default.
